### PR TITLE
Fix missing interest timestamp column

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -285,6 +285,9 @@ class SystemsManager {
         if (!usersInfo.some(col => col.name === 'rewardsLastShiftedAt')) {
             this.db.exec(`ALTER TABLE users ADD COLUMN rewardsLastShiftedAt INTEGER DEFAULT 0;`);
         }
+        if (!usersInfo.some(col => col.name === 'lastInterestTimestamp')) {
+            this.db.exec(`ALTER TABLE users ADD COLUMN lastInterestTimestamp INTEGER DEFAULT 0;`);
+        }
         const guildSettingsInfo = this.db.prepare("PRAGMA table_info(guildSettings)").all();
         if (!guildSettingsInfo.some(col => col.name === 'lastWeekendBoostStartAnnounceTimestamp')) {
             this.db.exec(`ALTER TABLE guildSettings ADD COLUMN lastWeekendBoostStartAnnounceTimestamp INTEGER DEFAULT 0;`);


### PR DESCRIPTION
## Summary
- ensure `lastInterestTimestamp` is added to the users table during initialization

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684833a3cdd8832c976813b9c8a7e2c4