### PR TITLE
Add bank max role and daily notifications

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const packageJson = require('./package.json');
 const { loadGiveaways, saveGiveaways } = require('./utils/dataManager.js');
 const { handleGiveawaySetupInteraction, handleEnterGiveaway, handleClaimPrize, activeGiveaways, endGiveaway, sendSetupChannelMessage, startInstantGiveaway } = require('./utils/giveawayManager.js');
 const { startGitHubWebhookServer } = require("./githubWebhook.js");
+const deployCommands = require('./deployCommands.js');
 
 
 function normalizePath(filePath) {
@@ -88,6 +89,11 @@ const USER_MANAGEMENT_PANEL_TIMEOUT_MS = 15 * 60 * 1000; // New timeout for /add
 const SHOP_CHECK_INTERVAL_MS = 1 * 60 * 1000;
 const UNBOXING_ANIMATION_DURATION_MS = 3550;
 const STREAK_LOSS_CHECK_INTERVAL_MS = 1 * 60 * 60 * 1000; // Check for lost streaks every hour
+const DAILY_READY_CHECK_INTERVAL_MS = 5 * 60 * 1000; // Check for ready daily every 5 minutes
+
+const BANK_MAXED_ROLE_ID = '1380872298143416340';
+// Guild ID whose icon should be used for the bot avatar
+const AVATAR_SYNC_GUILD_ID = process.env.GUILD_ID;
 
 const SPECIAL_ROLE_CHANCE = parseInt(process.env.SPECIAL_ROLE_CHANCE) || 1000000;
 const VERY_RARE_ITEM_ALERT_CHANNEL_ID = process.env.VERY_RARE_ITEM_ALERT_CHANNEL_ID || LOOTBOX_DROP_CHANNEL_ID;
@@ -548,6 +554,7 @@ async function scheduleStreakLossCheck(client) {
                 if (timeSinceLastClaim > streakLossThreshold) {
                     const oldStreak = user.dailyStreak;
                     client.levelSystem.resetDailyStreak(user.userId, user.guildId);
+                    const expireTs = Math.floor((Date.now() + 24 * 60 * 60 * 1000) / 1000);
 
                     try {
                         const discordUser = await client.users.fetch(user.userId);
@@ -559,7 +566,7 @@ async function scheduleStreakLossCheck(client) {
                             .setDescription(`Oh no! You missed your daily check-in and your streak of **${oldStreak} days** has been reset.`)
                             .addFields(
                                 { name: '💔 What Happened?', value: 'Daily streaks must be maintained by claiming your reward at least once every 36 hours.' },
-                                { name: '💎 Restore Your Streak?', value: `You can restore your streak for **${costToRestore}** ${client.levelSystem.gemEmoji}. This is a one-time offer!` }
+                                { name: '💎 Restore Your Streak?', value: `You can restore your streak for **${costToRestore}** ${client.levelSystem.gemEmoji}. This offer expires <t:${expireTs}:R>.` }
                             )
                             .setFooter({ text: 'Use the button below or the /daily restore-streak command.' });
 
@@ -717,6 +724,49 @@ async function scheduleWeekendBoosts(client) {
     // initial + interval
     await checkWeekendStatus();
     setInterval(checkWeekendStatus, WEEKEND_CHECK_INTERVAL_MS);
+}
+
+async function scheduleDailyReadyNotifications(client) {
+    console.log("[Daily Notify Scheduler] Initializing daily ready notifications...");
+    const checkReady = async () => {
+        try {
+            const rows = client.levelSystem.getUsersForDailyReadyNotification();
+            const now = Date.now();
+            const cooldown = 12 * 60 * 60 * 1000;
+            for (const row of rows) {
+                const nextClaim = (row.lastDailyTimestamp || 0) + cooldown;
+                if (now >= nextClaim && (row.lastDailyNotifyTimestamp || 0) <= (row.lastDailyTimestamp || 0)) {
+                    try {
+                        const userObj = await client.users.fetch(row.userId);
+                        await userObj.send({ content: `<@${row.userId}> your daily reward is ready! Use /daily check in the server.` }).catch(e => { if (e.code !== 50007) console.warn(`[DailyNotify] DM failed for ${row.userId}: ${e.message}`); });
+                    } catch (e) {
+                        if (e.code !== 50007) console.warn(`[DailyNotify] Could not notify ${row.userId}: ${e.message}`);
+                    }
+                    client.levelSystem.updateUser(row.userId, row.guildId, { lastDailyNotifyTimestamp: now });
+                }
+            }
+        } catch (err) {
+            console.error('[Daily Notify Scheduler] Error:', err);
+        }
+    };
+    await checkReady();
+    setInterval(checkReady, DAILY_READY_CHECK_INTERVAL_MS);
+}
+
+async function syncBotAvatarWithGuild(client) {
+    if (!AVATAR_SYNC_GUILD_ID) return;
+    try {
+        const guild = await client.guilds.fetch(AVATAR_SYNC_GUILD_ID);
+        const iconURL = guild?.iconURL({ extension: 'png', size: 1024 });
+        if (!iconURL) return;
+        const current = client.user.avatarURL({ extension: 'png', size: 1024 });
+        if (current !== iconURL) {
+            await client.user.setAvatar(iconURL);
+            console.log('[AvatarSync] Bot avatar updated to guild icon.');
+        }
+    } catch (err) {
+        console.error('[AvatarSync] Failed to sync avatar with guild icon:', err);
+    }
 }
 
 async function safeEditReply(interaction, options, deleteAfter = false, timeout = DEFAULT_REPLY_DELETE_TIMEOUT) {
@@ -1404,6 +1454,16 @@ client.once('ready', async c => {
     console.log(`Logged in as ${c.user.tag}! Bot is ready at ${new Date().toISOString()}.`);
     startGitHubWebhookServer(c);
 
+    // Sync bot avatar with guild icon on startup
+    await syncBotAvatarWithGuild(c);
+
+    try {
+        await deployCommands();
+        console.log('[Startup] Slash commands deployed.');
+    } catch (deployErr) {
+        console.error('[Startup] Failed to deploy slash commands:', deployErr);
+    }
+
     try {
         const commandFiles = fsSync.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
         for (const file of commandFiles) {
@@ -1569,6 +1629,7 @@ if (client.levelSystem && client.levelSystem.shopManager) {
 }
 
 scheduleStreakLossCheck(client);
+scheduleDailyReadyNotifications(client);
 
     // Config checks
     if (!LEVEL_UP_CHANNEL_ID) console.warn("[Config Check] LEVEL_UP_CHANNEL_ID not defined.");
@@ -1869,6 +1930,14 @@ client.on('interactionCreate', async interaction => {
                     }
                     const result = client.levelSystem.attemptStreakRestore(interaction.user.id, interaction.guild.id);
                      await safeEditReply(interaction, { content: result.message, ephemeral: true });
+                } else if (subcommand === 'notify') {
+                    if (!interaction.replied && !interaction.deferred) {
+                        await interaction.deferReply({ ephemeral: true });
+                        deferredThisInteraction = true;
+                    }
+                    const enable = interaction.options.getBoolean('enable');
+                    client.levelSystem.updateUserDmSettings(interaction.user.id, interaction.guild.id, { enableDailyReadyDm: enable });
+                    await safeEditReply(interaction, { content: `Daily ready notifications ${enable ? 'enabled' : 'disabled'}.`, ephemeral: true });
                 }
                 return;
             }
@@ -3359,6 +3428,19 @@ client.on('interactionCreate', async interaction => {
         // Send an ephemeral follow-up to the user with the result
         await interaction.followUp({ content: upgradeResult.message, ephemeral: true }).catch(e => console.warn("Bank upgrade followup failed:", e.message));
 
+        if (upgradeResult.success && upgradeResult.newTier && upgradeResult.newTier >= 10) {
+            try {
+                const role = interaction.guild.roles.cache.get(BANK_MAXED_ROLE_ID);
+                if (role && interaction.guild.members.me.permissions.has(PermissionsBitField.Flags.ManageRoles) && interaction.guild.members.me.roles.highest.position > role.position) {
+                    if (!interaction.member.roles.cache.has(BANK_MAXED_ROLE_ID)) {
+                        await interaction.member.roles.add(role).catch(() => {});
+                    }
+                }
+            } catch (e) {
+                console.warn(`[BankUpgradeRole] Failed to assign role: ${e.message}`);
+            }
+        }
+
         // After all interaction responses are done, update the original message panel
         try {
             const updatedBankEmbed = await buildBankEmbed(interaction.user, interaction.guild.id, client.levelSystem);
@@ -3803,6 +3885,20 @@ client.on('guildMemberRemove', async member => {
 
     } catch (error) {
         console.error(`[GuildMemberRemove] Error handling member leaving ${member.user.tag}:`, error);
+    }
+});
+
+client.on('guildUpdate', async (oldGuild, newGuild) => {
+    if (newGuild.id !== AVATAR_SYNC_GUILD_ID) return;
+    const iconURL = newGuild.iconURL({ extension: 'png', size: 1024 });
+    if (!iconURL) return;
+    const current = client.user.avatarURL({ extension: 'png', size: 1024 });
+    if (current === iconURL) return;
+    try {
+        await client.user.setAvatar(iconURL);
+        console.log('[AvatarSync] Bot avatar updated due to guild icon change.');
+    } catch (err) {
+        console.error('[AvatarSync] Failed to update avatar on guild update:', err);
     }
 });
 


### PR DESCRIPTION
## Summary
- award a special role when a user's bank reaches the max tier
- add periodic DM alerts for when daily rewards are ready
- let users enable/disable daily alerts via `/daily notify`
- streak restore offers expire after 24h
- automatically deploy slash commands on startup
- sync bot avatar with the guild icon
- fix missing newline at EOF for several files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684857f89b3c832c8516898ee9902fbe