### PR TITLE
Add new settings command

### DIFF
--- a/commands/set-setting.js
+++ b/commands/set-setting.js
@@ -1,0 +1,11 @@
+// commands/set-setting.js
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('set-setting')
+        .setDescription('Configure your personal alert settings.'),
+    async execute(interaction) {
+        await interaction.reply({ content: 'Opening settings panel...', ephemeral: true });
+    },
+};

--- a/commands/usersettings.js
+++ b/commands/usersettings.js
@@ -1,5 +1,5 @@
 // commands/usersettings.js
-const { SlashCommandBuilder, ApplicationCommandOptionType } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -10,38 +10,7 @@ module.exports = {
                 .setName('view')
                 .setDescription('View your current bot settings.')
         )
-        .addSubcommand(subcommand =>
-            subcommand
-                .setName('toggle-shop-dm')
-                .setDescription('Enable/disable DM notifications for rare items/discounts in the shop.')
-        )
-        .addSubcommand(subcommand =>
-            subcommand
-                .setName('set-rarity-alert')
-                .setDescription('Set rarity threshold for item drop alerts in the public channel (e.g., 1000 for 1-in-1000).')
-                .addIntegerOption(option =>
-                    option.setName('threshold')
-                        .setDescription('Enter rarity (e.g., 1000 for 1-in-1000). 0 to disable.')
-                        .setRequired(true)
-                        .setMinValue(0)
-                )
-        )
-        .addSubcommand(subcommand =>
-            subcommand
-                .setName('set-item-alert')
-                .setDescription('Enable/disable public channel announcements for specific items you find.')
-                .addStringOption(option =>
-                    option.setName('item_id_alert')
-                        .setDescription('The ID or name of the item to configure alerts for.')
-                        .setRequired(true)
-                        .setAutocomplete(true) // Enable autocomplete for item ID/name
-                )
-                .addBooleanOption(option =>
-                    option.setName('status')
-                        .setDescription('Enable or disable public channel alerts for this item type.')
-                        .setRequired(true)
-                )
-        ),
+        ,
     async execute(interaction) {
         // This command's logic is primarily handled in index.js for fetching and updating user settings.
         // It's defined here for command deployment.

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -337,47 +337,12 @@ const commands = [
                 name: 'view',
                 description: 'View your current bot settings.',
                 type: ApplicationCommandOptionType.Subcommand,
-            },
-            {
-                name: 'toggle-shop-dm',
-                description: 'Enable/disable DM notifications for rare items/discounts in the shop.',
-                type: ApplicationCommandOptionType.Subcommand,
-            },
-            {
-                name: 'set-rarity-alert',
-                description: 'Set rarity threshold for item drop alerts in the public channel (e.g., 1000 for 1-in-1000).',
-                type: ApplicationCommandOptionType.Subcommand,
-                options: [
-                    {
-                        name: 'threshold',
-                        description: 'Enter rarity (e.g., 1000 for 1-in-1000). 0 to disable.',
-                        type: ApplicationCommandOptionType.Integer,
-                        required: true,
-                        minValue: 0
-                    }
-                ]
-            },
-            {
-                name: 'set-item-alert',
-                description: 'Enable/disable public channel announcements for specific items you find.',
-                type: ApplicationCommandOptionType.Subcommand,
-                options: [
-                    {
-                        name: 'item_id_alert',
-                        description: 'The ID or name of the item to configure alerts for.',
-                        type: ApplicationCommandOptionType.String,
-                        required: true,
-                        autocomplete: true
-                    },
-                    {
-                        name: 'status',
-                        description: 'Enable or disable public channel alerts for this item type.',
-                        type: ApplicationCommandOptionType.Boolean,
-                        required: true,
-                    }
-                ]
             }
         ]
+    },
+    {
+        name: 'set-setting',
+        description: 'Configure your personal alert settings.',
     },
     {
         name: 'delete-all-commands',
@@ -446,19 +411,6 @@ const commands = [
                 name: 'restore-streak',
                 description: 'Use gems to restore your lost daily streak.',
                 type: ApplicationCommandOptionType.Subcommand,
-            },
-            {
-                name: 'notify',
-                description: 'Enable or disable notifications when your daily reward is ready.',
-                type: ApplicationCommandOptionType.Subcommand,
-                options: [
-                    {
-                        name: 'enable',
-                        description: 'Enable notifications',
-                        type: ApplicationCommandOptionType.Boolean,
-                        required: true,
-                    }
-                ]
             }
         ]
     }

--- a/index.js
+++ b/index.js
@@ -337,6 +337,39 @@ async function buildDailyEmbed(interaction, client) {
 }
 // --- End Helper Functions for /daily ---
 
+function buildSettingsEmbed(userId, guildId, systemsManager) {
+    const userDm = systemsManager.getUserDmSettings(userId, guildId);
+    const globalAlert = systemsManager.getUserGlobalLootAlertSettings(userId, guildId);
+    const dailyEnabled = userDm.enableDailyReadyDm ? SETTINGS_EMOJI_ENABLED : SETTINGS_EMOJI_DISABLED;
+
+    const embed = new EmbedBuilder()
+        .setColor(0x5865F2)
+        .setTitle('⚙️ User Settings')
+        .setDescription('Configure your alert preferences.')
+        .addFields(
+            { name: 'Daily Ready Alert', value: `${dailyEnabled} Once your daily is ready, it will notify you.` },
+            { name: 'Item Rarity Alert', value: `\`${globalAlert.alertRarityThreshold}\` Any item rarer than your set rarity will be notified.` },
+            { name: 'Shop Notify', value: 'Use the buttons below to configure shop alerts.' }
+        );
+
+    const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+            .setCustomId('setting_toggle_daily')
+            .setLabel(userDm.enableDailyReadyDm ? 'Disable Daily Alert' : 'Enable Daily Alert')
+            .setStyle(userDm.enableDailyReadyDm ? ButtonStyle.Danger : ButtonStyle.Success),
+        new ButtonBuilder()
+            .setCustomId('setting_set_rarity')
+            .setLabel('Change Rarity Threshold')
+            .setStyle(ButtonStyle.Primary),
+        new ButtonBuilder()
+            .setCustomId('setting_shop')
+            .setLabel('Shop Settings')
+            .setStyle(ButtonStyle.Secondary)
+    );
+
+    return { embed, components: [row] };
+}
+
 // --- Helper Functions for /withdraw-robux ---
 function buildRobuxWithdrawalRequestEmbed(withdrawalRequest, targetUser) {
     const robuxEmoji = client.levelSystem.robuxEmoji || DEFAULT_ROBUX_EMOJI_FALLBACK;
@@ -1872,12 +1905,6 @@ client.on('interactionCreate', async interaction => {
                     .filter(item => item.name.toLowerCase().includes(searchTerm) || item.id.toLowerCase().includes(searchTerm))
                     .map(item => ({ name: `${item.name} (ID: ${item.id})`, value: item.id }))
                     .slice(0, 25);
-            } else if (commandName === 'usersettings' && interaction.options.getSubcommand(false) === 'set-item-alert' && focusedValue.name === 'item_id_alert') {
-                choices = Object.values(client.levelSystem.gameConfig.items)
-                    .filter(item => item.type !== client.levelSystem.itemTypes.JUNK && item.type !== client.levelSystem.itemTypes.CURRENCY)
-                    .filter(item => item.name.toLowerCase().includes(searchTerm) || item.id.toLowerCase().includes(searchTerm))
-                    .map(item => ({ name: `${item.name} (ID: ${item.id})`, value: item.id }))
-                    .slice(0, 25);
             } else if (commandName === 'item-info' && focusedValue.name === 'item_name') {
                  choices = Object.values(client.levelSystem.gameConfig.items)
                     .filter(item => item.type !== client.levelSystem.itemTypes.JUNK)
@@ -1925,14 +1952,6 @@ client.on('interactionCreate', async interaction => {
                     }
                     const result = client.levelSystem.attemptStreakRestore(interaction.user.id, interaction.guild.id);
                      await safeEditReply(interaction, { content: result.message, ephemeral: true });
-                } else if (subcommand === 'notify') {
-                    if (!interaction.replied && !interaction.deferred) {
-                        await interaction.deferReply({ ephemeral: true });
-                        deferredThisInteraction = true;
-                    }
-                    const enable = interaction.options.getBoolean('enable');
-                    client.levelSystem.updateUserDmSettings(interaction.user.id, interaction.guild.id, { enableDailyReadyDm: enable });
-                    await safeEditReply(interaction, { content: `Daily ready notifications ${enable ? 'enabled' : 'disabled'}.`, ephemeral: true });
                 }
                 return;
             }
@@ -2352,38 +2371,16 @@ client.on('interactionCreate', async interaction => {
                             .setFooter({text: "Use subcommands to change settings."});
                         await safeEditReply(interaction, { embeds: [settingsEmbed], ephemeral: true });
                     }
-                    else if (subcommand === 'toggle-shop-dm') {
-                        const currentSetting = client.levelSystem.getUserDmSettings(userId, guildId).enableShopRestockDm;
-                        const guildDefault = client.levelSystem.getGuildSettings(guildId).shopRestockDmEnabled; // Get guild's default
-                        let newSettingValue;
-                        // Cycle: Explicit True -> Explicit False -> Guild Default (null) -> Explicit True
-                        if (currentSetting === true) newSettingValue = false; // True to False
-                        else if (currentSetting === false) newSettingValue = null; // False to Default
-                        else if (currentSetting === null && guildDefault) newSettingValue = false; // Default (if true) to False
-                        else newSettingValue = true; // Default (if false) or any other case to True
-
-                        client.levelSystem.updateUserDmSettings(userId, guildId, { enableShopRestockDm: newSettingValue });
-                        let statusMessage = "";
-                        if (newSettingValue === true) statusMessage = "Enabled.";
-                        else if (newSettingValue === false) statusMessage = "Disabled.";
-                        else statusMessage = "Reset to guild default."; // newSettingValue is null
-                        await safeEditReply(interaction, { content: `✅ Shop restock DMs ${statusMessage}`, ephemeral: true });
-                    }
-                    else if (subcommand === 'set-rarity-alert') {
-                        const threshold = interaction.options.getInteger('threshold');
-                        if (threshold < 0) return sendInteractionError(interaction, "Threshold must be 0 or positive.", true, deferredThisInteraction);
-                        client.levelSystem.setUserGlobalLootAlertSettings(userId, guildId, threshold);
-                        await safeEditReply(interaction, { content: `✅ Global loot alert rarity threshold set to \`${threshold}\`.`, ephemeral: true });
-                    }
-                    else if (subcommand === 'set-item-alert') {
-                        const itemIdToToggle = interaction.options.getString('item_id_alert');
-                        const enable = interaction.options.getBoolean('enable');
-                        const itemConf = client.levelSystem._getItemMasterProperty(itemIdToToggle, null); // Get full config
-                        if (!itemConf || itemConf.type === client.levelSystem.itemTypes.JUNK || itemConf.type === client.levelSystem.itemTypes.CURRENCY) return sendInteractionError(interaction, `Invalid or non-alertable item ID: ${itemIdToToggle}.`, true, deferredThisInteraction);
-                        client.levelSystem.setUserItemLootAlertSetting(userId, guildId, itemIdToToggle, enable);
-                        await safeEditReply(interaction, { content: `✅ Alerts for ${itemConf.name} ${enable ? 'enabled' : 'disabled'}.`, ephemeral: true });
-                    }
+                    
                 } catch (userSettingsError) { console.error('[UserSettings Error]', userSettingsError); await sendInteractionError(interaction, 'Error managing settings.', true, deferredThisInteraction); }
+                return;
+            }
+            if (commandName === 'set-setting') {
+                if (!interaction.replied && !interaction.deferred) { await interaction.deferReply({ ephemeral: true }); deferredThisInteraction = true; }
+                try {
+                    const { embed, components } = buildSettingsEmbed(interaction.user.id, interaction.guild.id, client.levelSystem);
+                    await safeEditReply(interaction, { embeds: [embed], components, ephemeral: true });
+                } catch (settingsError) { console.error('[SetSetting Error]', settingsError); await sendInteractionError(interaction, 'Failed to display settings.', true, deferredThisInteraction); }
                 return;
             }
             if (commandName === 'item-info') {
@@ -2670,6 +2667,52 @@ client.on('interactionCreate', async interaction => {
                         await sendInteractionError(interaction, result.message || "Failed to claim reward.", true, deferredThisInteraction);
                     }
                 } catch (claimError) { console.error('[ClaimDaily Error]', claimError); await sendInteractionError(interaction, "An error occurred while claiming your reward.", true, deferredThisInteraction); }
+                return;
+            }
+            if (customId === 'setting_toggle_daily') {
+                if (!interaction.isButton()) return;
+                if (!interaction.replied && !interaction.deferred) { await interaction.deferUpdate().catch(()=>{}); }
+                const userId = interaction.user.id; const guildId = interaction.guild.id;
+                const current = client.levelSystem.getUserDmSettings(userId, guildId).enableDailyReadyDm;
+                const newVal = current ? false : true;
+                client.levelSystem.updateUserDmSettings(userId, guildId, { enableDailyReadyDm: newVal });
+                const { embed, components } = buildSettingsEmbed(userId, guildId, client.levelSystem);
+                if (interaction.message && interaction.message.editable) {
+                    await interaction.message.edit({ embeds: [embed], components }).catch(()=>{});
+                }
+                return;
+            }
+            if (customId === 'setting_set_rarity') {
+                if (!interaction.isButton()) return;
+                if (!interaction.replied && !interaction.deferred) { await interaction.deferReply({ ephemeral: true }); deferredThisInteraction = true; }
+                const modal = new ModalBuilder()
+                    .setCustomId('setting_rarity_modal')
+                    .setTitle('Set Rarity Threshold');
+                const input = new TextInputBuilder()
+                    .setCustomId('rarity_threshold_input')
+                    .setLabel('Rarity value (e.g., 1000)')
+                    .setStyle(TextInputStyle.Short)
+                    .setRequired(true);
+                modal.addComponents(new ActionRowBuilder().addComponents(input));
+                await interaction.showModal(modal).catch(async e => { console.error('Show modal error', e); await sendInteractionError(interaction, 'Failed to show input.', true, deferredThisInteraction); });
+                return;
+            }
+            if (customId === 'setting_rarity_modal') {
+                if (!interaction.isModalSubmit()) return;
+                if (!interaction.replied && !interaction.deferred) { await interaction.deferReply({ ephemeral: true }); deferredThisInteraction = true; }
+                const val = parseInt(interaction.fields.getTextInputValue('rarity_threshold_input'));
+                if (isNaN(val) || val < 0) {
+                    return sendInteractionError(interaction, 'Invalid number.', true, deferredThisInteraction);
+                }
+                client.levelSystem.setUserGlobalLootAlertSettings(interaction.user.id, interaction.guild.id, val);
+                const { embed, components } = buildSettingsEmbed(interaction.user.id, interaction.guild.id, client.levelSystem);
+                await safeEditReply(interaction, { embeds: [embed], components, ephemeral: true });
+                return;
+            }
+            if (customId === 'setting_shop') {
+                if (!interaction.isButton()) return;
+                if (!interaction.replied && !interaction.deferred) { await interaction.deferReply({ ephemeral: true }); deferredThisInteraction = true; }
+                await safeEditReply(interaction, { content: 'Shop setting configuration coming soon.', ephemeral: true });
                 return;
             }
             if (customId.startsWith('restore_streak_confirm_')) {


### PR DESCRIPTION
## Summary
- remove unused user settings subcommands
- add `/set-setting` slash command skeleton
- implement helper to build user settings embeds
- support toggling daily alerts and changing rarity threshold
- register new command

## Testing
- `node --check index.js`
- `node --check commands/usersettings.js`
- `node --check commands/set-setting.js`
- `node --check deployCommands.js`

------
https://chatgpt.com/codex/tasks/task_e_68495aef85c0832c95d14dbd9b301a9d