### PR TITLE
Fix DM interaction deferral

### DIFF
--- a/index.js
+++ b/index.js
@@ -1992,7 +1992,8 @@ client.on('interactionCreate', async interaction => {
                     }
                 } else if (subcommand === 'restore-streak') {
                      if (!interaction.replied && !interaction.deferred) {
-                        await interaction.deferReply({ ephemeral: true });
+                        const deferOpts = interaction.guild ? { ephemeral: true } : {};
+                    await interaction.deferReply(deferOpts);
                         deferredThisInteraction = true;
                     }
                     const result = client.levelSystem.attemptStreakRestore(interaction.user.id, interaction.guild.id);
@@ -2068,7 +2069,8 @@ client.on('interactionCreate', async interaction => {
                 if (!targetMemberForCmd) return sendInteractionError(interaction, "The specified user is not a member of this server.", true);
 
                 if (!interaction.replied && !interaction.deferred) {
-                    await interaction.deferReply({ ephemeral: true });
+                    const deferOpts = interaction.guild ? { ephemeral: true } : {};
+                    await interaction.deferReply(deferOpts);
                     deferredThisInteraction = true;
                 }
 
@@ -2693,7 +2695,8 @@ client.on('interactionCreate', async interaction => {
             if (customId === 'claim_daily_reward') {
                 if (!interaction.isButton()) return;
                 if (!interaction.replied && !interaction.deferred) {
-                    await interaction.deferReply({ ephemeral: true });
+                    const deferOpts = interaction.guild ? { ephemeral: true } : {};
+                    await interaction.deferReply(deferOpts);
                     deferredThisInteraction = true;
                 }
                 try {
@@ -2833,8 +2836,9 @@ client.on('interactionCreate', async interaction => {
                 const guildId = parts[3];
                 const oldStreak = parseInt(parts[4]);
 
-                 if (!interaction.replied && !interaction.deferred) {
-                    await interaction.deferReply({ ephemeral: true });
+                if (!interaction.replied && !interaction.deferred) {
+                    const deferOpts = interaction.guild ? { ephemeral: true } : {};
+                    await interaction.deferReply(deferOpts);
                     deferredThisInteraction = true;
                 }
 

--- a/utils/giveawayManager.js
+++ b/utils/giveawayManager.js
@@ -1387,11 +1387,11 @@ async function handleClaimPrize(interaction, activeGiveawaysMap) {
     const messageId = parts[1];
     const winnerId = parts[2];
 
-    // Defer the interaction immediately and ephemerally
+    // Defer the interaction. Ephemeral replies are not allowed in DMs
     if (!interaction.deferred && !interaction.replied) {
-        await interaction.deferReply({ ephemeral: true }).catch(e => {
+        const deferOptions = interaction.guild ? { ephemeral: true } : {};
+        await interaction.deferReply(deferOptions).catch(e => {
             console.error('[handleClaimPrize] Failed to deferReply:', e);
-            return;
         });
     }
 


### PR DESCRIPTION
## Summary
- avoid ephemeral replies in DM contexts for claim buttons
- do the same for streak restore buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849b79180ec832cab2aa7670fee7525