### PR TITLE
Fix currency display for loot boxes

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -484,6 +484,11 @@ class SystemsManager {
                 if (itemDetails.type === this.itemTypes.CURRENCY) {
                     const minQty = parseInt(itemDetails.min, 10); const maxQty = parseInt(itemDetails.max, 10);
                     if (!isNaN(minQty) && !isNaN(maxQty) && maxQty >= minQty) quantity = Math.floor(Math.random() * (maxQty - minQty + 1)) + minQty;
+                    const currencyId = itemDetails.subType;
+                    itemDetails.id = currencyId;
+                    itemDetails.name = this._getItemMasterProperty(currencyId, 'name') || currencyId;
+                    itemDetails.emoji = this._getItemMasterProperty(currencyId, 'emoji') || '💰';
+                    itemDetails.rarityValue = itemDetails.rarityValue || this._getItemMasterProperty(currencyId, 'rarityValue') || 0;
                 } else if (itemDetails.quantity) {
                     if (Array.isArray(itemDetails.quantity) && itemDetails.quantity.length === 2) {
                         const minQ = parseInt(itemDetails.quantity[0], 10); const maxQ = parseInt(itemDetails.quantity[1], 10);


### PR DESCRIPTION
## Summary
- ensure currency rewards from loot boxes have valid IDs, names, and emojis so they no longer appear as unknown items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849ba9babb4832cb04f35990d4fd1c7