### PR TITLE
Add leaderboard reward roles

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const {
     ROBUX_WITHDRAWAL_COOLDOWN_MS // New constant from systems.js
 } = require('./systems.js');
 
-const { postOrUpdateLeaderboard, formatLeaderboardEmbed, formatCoinLeaderboardEmbed, formatGemLeaderboardEmbed, formatValueLeaderboardEmbed } = require('./leaderboardManager.js');
+const { postOrUpdateLeaderboard, updateLeaderboardRewards, formatLeaderboardEmbed, formatCoinLeaderboardEmbed, formatGemLeaderboardEmbed, formatValueLeaderboardEmbed } = require('./leaderboardManager.js');
 const DEFAULT_COIN_EMOJI_FALLBACK = '<a:coin:1373568800783466567>';
 const DEFAULT_GEM_EMOJI_FALLBACK = '<a:gem:1374405019918401597>';
 const DEFAULT_ROBUX_EMOJI_FALLBACK = '<a:robux:1378395622683574353>'; // New
@@ -652,6 +652,7 @@ async function scheduleDailyLeaderboardUpdate(client) {
                         console.warn(`[Leaderboard Scheduler] Failed to update leaderboard for ${guild.name}: ${result.message}`);
                     }
                 }
+                await updateLeaderboardRewards(client, guildId, client.levelSystem);
             } catch (error) {
                 console.error(`[Leaderboard Scheduler] Error updating leaderboard for guild ${guild.name} (${guildId}):`, error);
             }


### PR DESCRIPTION
## Summary
- reward role for top leaderboard placements
- keep reward roles in sync each hour with leaderboard updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852f07fc764832ca02365ab8b2797dc