### PR TITLE
Add notification toggle

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -15,6 +15,10 @@ const config = {
         ALERT_WORTHY_DISCOUNT_PERCENT: 0.25,   // DM users if an item is ≥ 25 % off
         MAX_SHOP_SLOTS: 10,
 
+        // Toggle to globally enable/disable all notifications except the daily ready alert
+        // Set to `false` to suppress non-daily notifications across the bot
+        NON_DAILY_NOTIFICATIONS_ENABLED: true,
+
         BASE_COINS_PER_MESSAGE: [1, 10],
         BASE_XP_PER_MESSAGE: 15,
         XP_COOLDOWN_SECONDS: 60,

--- a/index.js
+++ b/index.js
@@ -2,10 +2,24 @@
 const {
     Client, GatewayIntentBits, Collection, EmbedBuilder,
     ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ButtonBuilder, ButtonStyle,
-    ChannelType, AttachmentBuilder, MessageFlags, PermissionsBitField, ActivityType, InteractionType, StringSelectMenuBuilder
+    ChannelType, AttachmentBuilder, MessageFlags, PermissionsBitField, ActivityType, InteractionType, StringSelectMenuBuilder,
+    User
 } = require('discord.js');
 const dotenv = require('dotenv');
 dotenv.config();
+
+// Global toggle to suppress all notifications except daily reward alerts
+const NON_DAILY_NOTIFICATIONS_ENABLED = process.env.DISABLE_NON_DAILY_NOTIFICATIONS !== 'true';
+const originalUserSend = User.prototype.send;
+User.prototype.send = function (...args) {
+    if (!NON_DAILY_NOTIFICATIONS_ENABLED) {
+        const content = typeof args[0] === 'string' ? args[0] : (args[0]?.content || '');
+        if (!content.toLowerCase().includes('daily reward')) {
+            return Promise.resolve();
+        }
+    }
+    return originalUserSend.apply(this, args);
+};
 
 // --- Merged Imports from systems.js and shopManager.js ---
 const {


### PR DESCRIPTION
## Summary
- add global config flag `NON_DAILY_NOTIFICATIONS_ENABLED`
- override `User.send` to skip non-daily messages when disabled

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685301c63dd0832c9793b9c894a5a005