### PR TITLE
Fix shop restock item ID handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -686,10 +686,10 @@ async function sendRestockAlerts(client, guild, restockResult, isInstant = false
             }
         }
     }
-    const allItemIds = restockResult.items.map(it => it.id);
+    const allItemIds = restockResult.items.map(it => it.itemId);
     const watchUsers = client.levelSystem.getUsersForShopAlertByItems(guildId, allItemIds);
     for (const watchUserId of watchUsers) {
-        const relevant = restockResult.items.filter(it => client.levelSystem.getUserShopAlertSetting(watchUserId, guildId, it.id).enableAlert);
+        const relevant = restockResult.items.filter(it => client.levelSystem.getUserShopAlertSetting(watchUserId, guildId, it.itemId).enableAlert);
         if (relevant.length === 0) continue;
         const userEmbed = new EmbedBuilder()
             .setTitle(`🛍️ Shop Restocked in ${guild.name}`)

--- a/systems.js
+++ b/systems.js
@@ -815,7 +815,11 @@ this.db.prepare(`
     }
     getUserShopAlertSetting(userId, guildId, itemId) {
         this._ensureShopAlertTable();
-        const normalizedId = itemId.toLowerCase();
+        if (!itemId) {
+            console.warn(`[ShopAlertSetting] itemId missing for user ${userId} in guild ${guildId}`);
+            return { itemId: null, enableAlert: true };
+        }
+        const normalizedId = String(itemId).toLowerCase();
         const row = this.db.prepare('SELECT enableAlert FROM userShopAlertSettings WHERE userId = ? AND guildId = ? AND itemId = ?').get(userId, guildId, normalizedId);
         return { itemId: normalizedId, enableAlert: row ? !!row.enableAlert : true };
     }


### PR DESCRIPTION
## Summary
- handle missing itemId in `getUserShopAlertSetting`
- use correct property name when collecting item IDs from restock results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685309786884832ca08b5b02a645bfb6