### PR TITLE
Fix toggle-notifications reply logic

### DIFF
--- a/commands/toggle-notifications.js
+++ b/commands/toggle-notifications.js
@@ -10,7 +10,24 @@ module.exports = {
                 .setDescription('Set to true to enable non-daily notifications.')
                 .setRequired(true))
         .setDefaultMemberPermissions(PermissionsBitField.Flags.Administrator),
-    async execute(interaction) {
-        await interaction.reply({ content: 'Processing notification toggle...', ephemeral: true });
+    async execute(interaction, client) {
+        const enabled = interaction.options.getBoolean('enabled');
+
+        // Only administrators can run this command
+        if (!interaction.memberPermissions.has(PermissionsBitField.Flags.Administrator)) {
+            const deniedMsg = { content: '❌ You do not have permission to use this command.', ephemeral: true };
+            if (interaction.deferred || interaction.replied) return interaction.editReply(deniedMsg);
+            return interaction.reply(deniedMsg);
+        }
+
+        // Update the client flag controlling notification behaviour
+        (client || interaction.client).NON_DAILY_NOTIFICATIONS_ENABLED = enabled;
+
+        const response = {
+            content: `✅ All non-daily notifications have been **${enabled ? 'ENABLED' : 'DISABLED'}**.`,
+            ephemeral: true
+        };
+        if (interaction.deferred || interaction.replied) return interaction.editReply(response);
+        return interaction.reply(response);
     },
 };


### PR DESCRIPTION
## Summary
- update `toggle-notifications` command
  - handle deferred interactions and permissions
  - update the client toggle flag and send a confirmation message

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68530dc09e14832cb9bf54a77229a055