### PR TITLE
Remove purchase success message

### DIFF
--- a/shopManager.js
+++ b/shopManager.js
@@ -427,7 +427,6 @@ class ShopManager {
             }
             return {
                 success: true,
-                message: `Successfully purchased ${amountToPurchase}x ${itemConfigMaster.emoji || '❓'} **${itemConfigMaster.name}** for ${totalCost.toLocaleString()} ${currencyEmojiForMessage}!${itemAddMessagePart}`,
                 itemId: shopItemEntry.itemId,
                 itemName: itemConfigMaster.name,
                 emoji: itemConfigMaster.emoji || '❓',


### PR DESCRIPTION
## Summary
- stop sending purchase success message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853f2a4ff8c832cb568a9d81123a355