### PR TITLE
Adjust daily luck effect

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -1863,12 +1863,13 @@ this.db.prepare(`
 
             const totalBaseProb = baseItemPool.reduce((sum, item) => sum + item.baseProb, 0);
             const itemLuckBoost = Math.min(10.0, streak * 0.01); // Max 1000% boost
-            
+
             let totalRareProb = 0;
             const dynamicPool = baseItemPool.map(item => {
                 const isRare = item.id !== this.COMMON_LOOT_BOX_ID && !item.noLuck;
                 const baseProbability = item.baseProb / totalBaseProb;
-                const finalProb = isRare ? baseProbability * (1 + itemLuckBoost) : baseProbability;
+                // Slightly stronger luck scaling so max boost is more impactful
+                const finalProb = isRare ? baseProbability * (1 + itemLuckBoost * 1.25) : baseProbability;
                 if (isRare) totalRareProb += finalProb;
                 return { ...item, finalProb };
             });


### PR DESCRIPTION
## Summary
- increase daily reward luck scaling so max luck is slightly stronger

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685546668810832c803e0a3e9e797fc2