### PR TITLE
Double weekend multipliers

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -55,9 +55,9 @@ const config = {
         /* ---------------------------------------------------------
          *  Weekend multipliers / discounts  🎉
          * --------------------------------------------------------- */
-        WEEKEND_COIN_MULTIPLIER: 2,
-        WEEKEND_GEM_MULTIPLIER:  2,
-        WEEKEND_XP_MULTIPLIER:   2,
+        WEEKEND_COIN_MULTIPLIER: 4,
+        WEEKEND_GEM_MULTIPLIER:  4,
+        WEEKEND_XP_MULTIPLIER:   4,
         WEEKEND_SHOP_STOCK_MULTIPLIER: 2,
         // Weekend range is defined in UTC+7.
         // The boost starts Saturday 00:00 UTC+7 and ends Monday 00:00 UTC+7.

--- a/systems.js
+++ b/systems.js
@@ -44,9 +44,9 @@ const BANK_TIERS = {
     10: { coinCap:5_000_000,  gemCap: 15_000,  upgradeCostCoins:       0,  upgradeCostGems:     0,  interestRate:10,  nextTier:null }
 };
 
-const WEEKEND_COIN_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_COIN_MULTIPLIER || 2;
-const WEEKEND_GEM_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_GEM_MULTIPLIER || 2;
-const WEEKEND_XP_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_XP_MULTIPLIER || 2;
+const WEEKEND_COIN_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_COIN_MULTIPLIER || 4;
+const WEEKEND_GEM_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_GEM_MULTIPLIER || 4;
+const WEEKEND_XP_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_XP_MULTIPLIER || 4;
 // Luck related multipliers removed
 const WEEKEND_SHOP_STOCK_MULTIPLIER = gameConfig.globalSettings?.WEEKEND_SHOP_STOCK_MULTIPLIER || 1;
 


### PR DESCRIPTION
## Summary
- double weekend multipliers for coins, gems and xp in `game_config`
- update default fallback multipliers in `systems.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68564fb49b14832cbf0c2c0a2fc02e6c