### PR TITLE
Add hidden ticket hunt feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const {
     Client, GatewayIntentBits, Collection, EmbedBuilder,
     ModalBuilder, TextInputBuilder, TextInputStyle, ActionRowBuilder, ButtonBuilder, ButtonStyle,
     ChannelType, AttachmentBuilder, MessageFlags, PermissionsBitField, ActivityType, InteractionType, StringSelectMenuBuilder,
-    User
+    User, Partials
 } = require('discord.js');
 const dotenv = require('dotenv');
 dotenv.config();
@@ -82,6 +82,7 @@ const { loadGiveaways, saveGiveaways } = require('./utils/dataManager.js');
 const { handleGiveawaySetupInteraction, handleEnterGiveaway, handleClaimPrize, activeGiveaways, endGiveaway, sendSetupChannelMessage, startInstantGiveaway } = require('./utils/giveawayManager.js');
 const { startGitHubWebhookServer } = require("./githubWebhook.js");
 const deployCommands = require('./deployCommands.js');
+const { initializeTicketHunt } = require('./ticketHunt.js');
 
 
 function normalizePath(filePath) {
@@ -287,7 +288,8 @@ const client = new Client({
     intents: [
         GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildVoiceStates, GatewayIntentBits.DirectMessages
-    ]
+    ],
+    partials: [Partials.Message, Partials.Reaction, Partials.Channel]
 });
 client.NON_DAILY_NOTIFICATIONS_ENABLED = process.env.DISABLE_NON_DAILY_NOTIFICATIONS !== 'true';
 
@@ -2012,6 +2014,8 @@ scheduleDailyReadyNotifications(client);
             console.error(`[Config Check] CRITICAL: Robux withdrawal log channel ID ${ROBUX_WITHDRAWAL_LOG_CHANNEL_ID} is invalid or bot cannot access it. Withdrawals will fail to log.`);
         }
     }
+
+    await initializeTicketHunt(client);
 });
 
 client.on('messageCreate', async message => {

--- a/ticketHunt.js
+++ b/ticketHunt.js
@@ -1,0 +1,89 @@
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const HINT_EMOJI_ID = '1385856492787204147';
+const HINT_EMOJI = `<:hintticket:${HINT_EMOJI_ID}>`;
+const ALERT_CHANNEL_ID = '1373564899199811625';
+
+const TICKETS = [
+  { channelId: '1373564899199811625', messageId: '1383659740974026873' },
+  { channelId: '1373578620634665052', messageId: '1377993787200110725' },
+  { channelId: '1380898970225606818', messageId: '1382405983963185307' },
+  { channelId: '1384209189726851163', messageId: '1384212637516042280' },
+  { channelId: '1379861638253121708', messageId: '1385232072523644970' },
+  { channelId: '1380834420189298718', messageId: '1380841372814282802' },
+  { channelId: '1372572234949853370', messageId: '1384871498258583633' },
+  { channelId: '1372572234949853374', messageId: '1385872247490744420' },
+  { channelId: '1372572234949853368', messageId: '1382310864375386293' }
+];
+
+const DATA_FILE = path.join(__dirname, 'data', 'ticket_hunt.json');
+
+async function loadFound() {
+  try {
+    const data = await fs.readFile(DATA_FILE, 'utf8');
+    const parsed = JSON.parse(data);
+    return new Set(parsed.found || []);
+  } catch {
+    return new Set();
+  }
+}
+
+async function saveFound(set) {
+  const dir = path.dirname(DATA_FILE);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(DATA_FILE, JSON.stringify({ found: Array.from(set) }, null, 2));
+}
+
+async function initializeTicketHunt(client) {
+  const found = await loadFound();
+
+  for (const { channelId, messageId } of TICKETS) {
+    if (found.has(messageId)) continue;
+    try {
+      const channel = await client.channels.fetch(channelId);
+      if (!channel || !channel.isTextBased()) continue;
+      const message = await channel.messages.fetch(messageId);
+      if (!message.reactions.cache.has(HINT_EMOJI_ID)) {
+        await message.react(HINT_EMOJI).catch(() => {});
+      }
+    } catch (err) {
+      console.error(`[TicketHunt] Failed to ensure reaction for ${messageId}:`, err.message);
+    }
+  }
+
+  client.on('messageReactionAdd', async (reaction, user) => {
+    if (user.bot) return;
+    try {
+      if (reaction.partial) await reaction.fetch();
+      if (reaction.message.partial) await reaction.message.fetch();
+    } catch {
+      return;
+    }
+
+    if (reaction.emoji.id !== HINT_EMOJI_ID) return;
+    const ticket = TICKETS.find(t => t.messageId === reaction.message.id);
+    if (!ticket || found.has(ticket.messageId)) return;
+
+    found.add(ticket.messageId);
+    await saveFound(found).catch(() => {});
+
+    try {
+      await reaction.remove();
+    } catch {
+      await reaction.users.remove(client.user.id).catch(() => {});
+      await reaction.users.remove(user.id).catch(() => {});
+    }
+
+    const alertChannel = await client.channels.fetch(ALERT_CHANNEL_ID).catch(() => null);
+    const link = `https://discord.com/channels/${reaction.message.guildId}/${ticket.channelId}/${ticket.messageId}`;
+    if (alertChannel && alertChannel.isTextBased()) {
+      await alertChannel.send(`\u2728 **${user.tag}** found a hidden ticket! \u2728\n${link}`);
+      if (found.size === TICKETS.length) {
+        await alertChannel.send('\ud83c\udfc6 **All tickets have been found!**');
+      }
+    }
+  });
+}
+
+module.exports = { initializeTicketHunt };


### PR DESCRIPTION
## Summary
- add new `ticketHunt.js` module to manage hidden ticket reactions
- register ticket hunt module in `index.js`
- enable message/reaction partials

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685654dbd888832c955ce77236ece6ef