### PR TITLE
Add start-hunt command

### DIFF
--- a/commands/start-hunt.js
+++ b/commands/start-hunt.js
@@ -1,0 +1,23 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { initializeTicketHunt } = require('../ticketHunt.js');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('start-hunt')
+    .setDescription('Enable the ticket hunt by reacting to all hunt messages.')
+    .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
+  async execute(interaction, client) {
+    if (!interaction.memberPermissions.has(PermissionsBitField.Flags.ManageGuild)) {
+      return interaction.reply({ content: '❌ You do not have permission to use this command.', ephemeral: true });
+    }
+    const c = client || interaction.client;
+    await interaction.reply({ content: '🔍 Starting the ticket hunt...', ephemeral: true });
+    try {
+      await initializeTicketHunt(c);
+      await interaction.editReply({ content: '✅ Ticket hunt started!' });
+    } catch (err) {
+      console.error(`[start-hunt] Failed to start hunt: ${err.message}`);
+      await interaction.editReply({ content: '❌ Failed to start ticket hunt.' });
+    }
+  },
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -449,6 +449,11 @@ const commands = [
             }
         ],
         default_member_permissions: PermissionsBitField.Flags.Administrator.toString()
+    },
+    {
+        name: 'start-hunt',
+        description: 'Enable the ticket hunt and add reactions to hunt messages.',
+        default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
     }
 ];
 

--- a/ticketHunt.js
+++ b/ticketHunt.js
@@ -14,7 +14,9 @@ const TICKETS = [
   { channelId: '1380834420189298718', messageId: '1380841372814282802' },
   { channelId: '1372572234949853370', messageId: '1384871498258583633' },
   { channelId: '1372572234949853374', messageId: '1385872247490744420' },
-  { channelId: '1372572234949853368', messageId: '1382310864375386293' }
+  { channelId: '1372572234949853368', messageId: '1382310864375386293' },
+  // TODO: Replace with the actual channel and message ID for the final ticket
+  { channelId: 'REPLACE_CHANNEL_ID', messageId: 'REPLACE_MESSAGE_ID' }
 ];
 
 const DATA_FILE = path.join(__dirname, 'data', 'ticket_hunt.json');


### PR DESCRIPTION
## Summary
- add `/start-hunt` command to manually enable the ticket hunt
- include new command in deployCommands script
- extend ticket hunt message list to allow 10 hunt messages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685656faec5c832c86a3a25e87c0e410