### PR TITLE
Fix ephemeral reply handling for start-hunt

### DIFF
--- a/commands/start-hunt.js
+++ b/commands/start-hunt.js
@@ -11,8 +11,11 @@ module.exports = {
       return interaction.reply({ content: '❌ You do not have permission to use this command.', ephemeral: true });
     }
     const c = client || interaction.client;
-    await interaction.reply({ content: '🔍 Starting the ticket hunt...', ephemeral: true });
+    if (!interaction.deferred && !interaction.replied) {
+      await interaction.deferReply({ ephemeral: true });
+    }
     try {
+      await interaction.editReply({ content: '🔍 Starting the ticket hunt...' });
       await initializeTicketHunt(c);
       await interaction.editReply({ content: '✅ Ticket hunt started!' });
     } catch (err) {


### PR DESCRIPTION
## Summary
- fix `start-hunt` command to work with deferred replies

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68565d33fa24832cad3ff318fd9641f4