### PR TITLE
Fix ticket hunt reaction handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,8 +286,13 @@ if (fsSync.existsSync(restoreCandidateDbPath)) {
 
 const client = new Client({
     intents: [
-        GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent,
-        GatewayIntentBits.GuildMembers, GatewayIntentBits.GuildVoiceStates, GatewayIntentBits.DirectMessages
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildVoiceStates,
+        GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.GuildMessageReactions
     ],
     partials: [Partials.Message, Partials.Reaction, Partials.Channel]
 });


### PR DESCRIPTION
## Summary
- enable `GuildMessageReactions` intent so reacting to hunt messages works

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685666f896f4832c9a8fcce6f9cdc5f6