### PR TITLE
Fix daily skip not resetting timer

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -2063,7 +2063,7 @@ this.db.prepare(`
         }
 
         this.updateUser(userId, guildId, {
-            lastDailyTimestamp: now,
+            // Don't update lastDailyTimestamp so the cooldown timer isn't reset
             dailySkipCount: skipCount + 1
         });
 


### PR DESCRIPTION
## Summary
- avoid resetting `lastDailyTimestamp` when skipping the daily reward so the original timer is preserved

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68566de63858832c850424e60c7fe332