### PR TITLE
Add user-specific option to admin reset command

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -321,6 +321,12 @@ const commands = [
                 required: true,
             },
             {
+                name: 'user',
+                description: 'Specific user to reset instead of all users',
+                type: ApplicationCommandOptionType.User,
+                required: false,
+            },
+            {
                 name: 'reset_all_users',
                 description: 'MUST BE TRUE to confirm this affects all users in the specified data types.',
                 type: ApplicationCommandOptionType.Boolean,


### PR DESCRIPTION
## Summary
- allow `admin-reset-data` to target a single user instead of whole guild
- support partial resets for that user in `LevelSystem`
- register new optional `user` slash-command option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856d893c3e0832c94459553c037b2bf