### PR TITLE
Update value leaderboard to use rarity value

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -600,8 +600,8 @@ class SystemsManager {
             let totalValue = 0;
             const inventory = this.db.prepare('SELECT itemId, quantity FROM userInventory WHERE userId = ? AND guildId = ? AND quantity > 0').all(user.userId, guildId);
             inventory.forEach(item => {
-                const basePrice = this._getItemMasterProperty(item.itemId, 'basePrice', 0);
-                if (typeof basePrice === 'number') totalValue += basePrice * item.quantity;
+                const rarityValue = this._getItemMasterProperty(item.itemId, 'rarityValue', 0);
+                if (typeof rarityValue === 'number') totalValue += rarityValue * item.quantity;
             });
             return { userId: user.userId, totalValue };
         });
@@ -635,8 +635,8 @@ class SystemsManager {
             let totalValue = 0;
             const inventory = this.db.prepare('SELECT itemId, quantity FROM userInventory WHERE userId = ? AND guildId = ? AND quantity > 0').all(user.userId, guildId);
             inventory.forEach(item => {
-                const basePrice = this._getItemMasterProperty(item.itemId, 'basePrice', 0);
-                if (typeof basePrice === 'number') totalValue += basePrice * item.quantity;
+                const rarityValue = this._getItemMasterProperty(item.itemId, 'rarityValue', 0);
+                if (typeof rarityValue === 'number') totalValue += rarityValue * item.quantity;
             });
             return { userId: user.userId, totalValue };
         });


### PR DESCRIPTION
## Summary
- compute leaderboard value from item rarity instead of base price

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856d98e8a74832c91a04527b8063f68