### PR TITLE
Update chest rewards with quantity ranges

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -253,12 +253,12 @@ const config = {
             itemPool: [
                 { type: "currency", subType: "coins", min: 100, max: 1000, probability: 0.35, rarityValue: 10 },
                 { type: "currency", subType: "gems", min: 50, max: 500, probability: 0.2, rarityValue: 25 },
-                { type: "loot_box_item", id: "common_loot_box", quantity: 1, probability: 0.25, rarityValue: 100 },
-                { type: "loot_box_item", id: "rare_loot_box", quantity: 1, probability: 0.14, rarityValue: 1000 },
-                { type: "loot_box_item", id: "epic_loot_box", quantity: 1, probability: 0.049, rarityValue: 50000 },
-                { type: "loot_box_item", id: "legendary_loot_box", quantity: 1, probability: 0.019, rarityValue: 250000 },
-                { type: "loot_box_item", id: "mythical_chest", quantity: 1, probability: 0.001, rarityValue: 750000 },
-                { type: "loot_box_item", id: "gem_chest", quantity: 1, probability: 0.0005, rarityValue: 500000 },
+                { type: "loot_box_item", id: "common_loot_box", min: 25, max: 100, probability: 0.25, rarityValue: 100 },
+                { type: "loot_box_item", id: "rare_loot_box", min: 10, max: 50, probability: 0.14, rarityValue: 1000 },
+                { type: "loot_box_item", id: "epic_loot_box", min: 5, max: 20, probability: 0.049, rarityValue: 50000 },
+                { type: "loot_box_item", id: "legendary_loot_box", min: 2, max: 10, probability: 0.019, rarityValue: 250000 },
+                { type: "loot_box_item", id: "mythical_chest", min: 1, max: 3, probability: 0.001, rarityValue: 750000 },
+                { type: "loot_box_item", id: "gem_chest", min: 1, max: 3, probability: 0.0005, rarityValue: 500000 },
                 { type: "cosmic_token", id: "cosmic_role_token", quantity: 1, probability: 0.000001, rarityValue: 1000000 }
             ]
         },

--- a/systems.js
+++ b/systems.js
@@ -532,6 +532,13 @@ class SystemsManager {
                     itemDetails.name = this._getItemMasterProperty(currencyId, 'name') || currencyId;
                     itemDetails.emoji = this._getItemMasterProperty(currencyId, 'emoji') || '💰';
                     itemDetails.rarityValue = itemDetails.rarityValue || this._getItemMasterProperty(currencyId, 'rarityValue') || 0;
+                } else if (!itemDetails.quantity && (itemDetails.min !== undefined || itemDetails.max !== undefined)) {
+                    const minQty = parseInt(itemDetails.min, 10); const maxQty = parseInt(itemDetails.max, 10);
+                    if (!isNaN(minQty) && !isNaN(maxQty) && maxQty >= minQty) {
+                        quantity = Math.floor(Math.random() * (maxQty - minQty + 1)) + minQty;
+                    } else if (!isNaN(minQty) && isNaN(maxQty)) {
+                        quantity = minQty;
+                    }
                 } else if (itemDetails.quantity) {
                     if (Array.isArray(itemDetails.quantity) && itemDetails.quantity.length === 2) {
                         const minQ = parseInt(itemDetails.quantity[0], 10); const maxQ = parseInt(itemDetails.quantity[1], 10);


### PR DESCRIPTION
## Summary
- support min/max quantity ranges for non-currency loot box items
- update `void_chest` to drop multiple chests using ranges

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856dba2cd00832c9063915697da5aa1