### PR TITLE
Fix required option ordering

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -321,16 +321,16 @@ const commands = [
                 required: true,
             },
             {
-                name: 'user',
-                description: 'Specific user to reset instead of all users',
-                type: ApplicationCommandOptionType.User,
-                required: false,
-            },
-            {
                 name: 'reset_all_users',
                 description: 'MUST BE TRUE to confirm this affects all users in the specified data types.',
                 type: ApplicationCommandOptionType.Boolean,
                 required: true,
+            },
+            {
+                name: 'user',
+                description: 'Specific user to reset instead of all users',
+                type: ApplicationCommandOptionType.User,
+                required: false,
             },
             {
                 name: 'reset_levels_xp',


### PR DESCRIPTION
## Summary
- ensure required options come before optional ones in the admin-reset-data slash command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685aad8622c8832cb1e5acd10c98e35c