### PR TITLE
Reduce shop restock interval

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -11,7 +11,7 @@ const config = {
         CHAT_DROP_BASE_CHANCE: 1,       // 1  ≘ 100 % base chance (tweak as needed)
         VOICE_DROP_BASE_CHANCE: 1,      // 1  ≘ 100 %
 
-        SHOP_RESTOCK_INTERVAL_MINUTES: parseInt(process.env.SHOP_RESTOCK_INTERVAL_MINUTES, 10) || 20,
+        SHOP_RESTOCK_INTERVAL_MINUTES: parseInt(process.env.SHOP_RESTOCK_INTERVAL_MINUTES, 10) || 5,
         ALERT_WORTHY_DISCOUNT_PERCENT: 0.25,   // DM users if an item is ≥ 25 % off
         MAX_SHOP_SLOTS: 10,
 

--- a/index.js
+++ b/index.js
@@ -822,7 +822,7 @@ async function scheduleShopRestock(client) {
                 }
                 const shopManagerInstance = client.levelSystem.shopManager;
                 const guildShopSettings = shopManagerInstance.getGuildShopSettings(guildId);
-                const currentShopIntervalMinutes = client.levelSystem.gameConfig.globalSettings.SHOP_RESTOCK_INTERVAL_MINUTES || 20;
+                const currentShopIntervalMinutes = client.levelSystem.gameConfig.globalSettings.SHOP_RESTOCK_INTERVAL_MINUTES || 5;
                 const currentShopIntervalMs = currentShopIntervalMinutes * 60 * 1000;
 
                 const lastRestockTime = guildShopSettings.lastRestockTimestamp || 0;
@@ -1019,7 +1019,7 @@ async function scheduleWeekendBoosts(client) {
             // Refresh shop timers when the weekend starts
             if (isCurrentlyWeekend && client.levelSystem.shopManager) {
                 const shopMgr    = client.levelSystem.shopManager;
-                const restockMs  = (client.levelSystem.gameConfig.globalSettings.SHOP_RESTOCK_INTERVAL_MINUTES || 20) * 60 * 1000;
+                const restockMs  = (client.levelSystem.gameConfig.globalSettings.SHOP_RESTOCK_INTERVAL_MINUTES || 5) * 60 * 1000;
                 shopMgr.updateGuildShopSettings(guildId, {
                     nextRestockTimestamp : now + restockMs,
                     lastRestockTimestamp : now
@@ -1366,7 +1366,7 @@ async function checkAndAwardSpecialRole(member, reason, purchasedItemName = null
 async function buildShopEmbed(guildId, systemsManager, shopManagerInstance) {
     const shopItems = shopManagerInstance.getShopItems(guildId);
     const guildShopSettings = shopManagerInstance.getGuildShopSettings(guildId);
-    const currentShopIntervalMinutes = systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 20;
+    const currentShopIntervalMinutes = systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 5;
     const currentShopIntervalSeconds = currentShopIntervalMinutes * 60;
     const embed = new EmbedBuilder()
         .setTitle(guildShopSettings.shopTitle || '🛒 Server Shop')

--- a/shopManager.js
+++ b/shopManager.js
@@ -121,7 +121,7 @@ class ShopManager {
         const stmt = this.db.prepare(`SELECT * FROM guildShopSettings WHERE guildId = ?`);
         let settings = stmt.get(guildId);
         const defaultShopTitle = this.systemsManager.gameConfig.globalSettings?.DEFAULT_SHOP_TITLE || '🛒 Server Shop';
-        const defaultRestockIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 20; 
+        const defaultRestockIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 5;
         const defaultRestockIntervalMs = defaultRestockIntervalMinutes * 60 * 1000;
 
          if (!settings) {
@@ -140,7 +140,7 @@ class ShopManager {
 
     setGuildShopSettings(guildId, settings) {
         const defaultShopTitle = this.systemsManager.gameConfig.globalSettings?.DEFAULT_SHOP_TITLE || '🛒 Server Shop';
-        const defaultRestockIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 20;
+        const defaultRestockIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 5;
         const defaultRestockIntervalMs = defaultRestockIntervalMinutes * 60 * 1000;
 
          const stmt = this.db.prepare(`
@@ -166,7 +166,7 @@ class ShopManager {
         try {
             const guildSettings = this.getGuildShopSettings(guildId);
             const nowMs = Date.now();
-            const configuredIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 20;
+            const configuredIntervalMinutes = this.systemsManager.gameConfig.globalSettings?.SHOP_RESTOCK_INTERVAL_MINUTES || 5;
             const actualRestockIntervalMs = configuredIntervalMinutes * 60 * 1000;
             const lastRestockMs = guildSettings.lastRestockTimestamp || 0;
             const nextScheduledRestockBasedOnConfigMs = lastRestockMs + actualRestockIntervalMs;


### PR DESCRIPTION
## Summary
- reduce the default shop restock time to 5 minutes in config
- adjust fallback values in `index.js` and `shopManager.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c03171510832cb5c8e6f66f6ab994