### PR TITLE
Fix shop restock interval

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -11,7 +11,9 @@ const config = {
         CHAT_DROP_BASE_CHANCE: 1,       // 1  ≘ 100 % base chance (tweak as needed)
         VOICE_DROP_BASE_CHANCE: 1,      // 1  ≘ 100 %
 
-        SHOP_RESTOCK_INTERVAL_MINUTES: parseInt(process.env.SHOP_RESTOCK_INTERVAL_MINUTES, 10) || 5,
+        // Restock interval for the shop in minutes. Hard-coded to 5 to prevent
+        // environment variables from overriding this value unintentionally.
+        SHOP_RESTOCK_INTERVAL_MINUTES: 5,
         ALERT_WORTHY_DISCOUNT_PERCENT: 0.25,   // DM users if an item is ≥ 25 % off
         MAX_SHOP_SLOTS: 10,
 


### PR DESCRIPTION
## Summary
- set `SHOP_RESTOCK_INTERVAL_MINUTES` to 5 minutes in game config to avoid env overrides

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c0e9c395c832c9b4deba79922170e