### PR TITLE
Update battle pass level 100 reward

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -383,6 +383,11 @@ const config = {
             emoji: "<:rainbow100:1387285530865176687>", rarityValue: 0,
             description: "Apply a 100% discount to a shop purchase."
         },
+        "gift_card_25": {
+            id: "gift_card_25", name: "25$ Giftcard", type: "item",
+            emoji: "<a:robux:1378395622683574353>", rarityValue: 0,
+            description: "A $25 gift card."
+        },
         "daily_skip_ticket": {
             id: "daily_skip_ticket", name: "Daily Skip Ticket", type: "item",
             emoji: "<:dailyskip:1387286893338693764>", rarityValue: 0,

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ const ITEM_IDS = {
     DISCOUNT_25: gameConfig.items.discount_ticket_25?.id || 'discount_ticket_25',
     DISCOUNT_50: gameConfig.items.discount_ticket_50?.id || 'discount_ticket_50',
     DISCOUNT_100: gameConfig.items.discount_ticket_100?.id || 'discount_ticket_100',
+    GIFT_CARD_25: gameConfig.items.gift_card_25?.id || 'gift_card_25',
 };
 
 const fs = require('node:fs').promises;
@@ -1512,6 +1513,7 @@ function buildBattlePassEmbed(userId, guildId, client) {
         embed.addFields({ name: `${info.level}`, value: text, inline: true });
     }
     embed.addFields({ name: 'Battle Pass ends', value: `<t:${Math.floor(BATTLE_PASS_END/1000)}:R>` });
+    embed.addFields({ name: 'How to gain BP XP', value: 'Earn BP XP by chatting, opening loot boxes, and claiming daily rewards.' });
     const claimDisabled = progress.level <= progress.lastClaim;
     const button = new ActionRowBuilder().addComponents(
         new ButtonBuilder().setCustomId('bp_claim_reward').setLabel('Claim').setStyle(ButtonStyle.Success).setDisabled(claimDisabled).setEmoji('🎁')

--- a/utils/battlePassRewards.js
+++ b/utils/battlePassRewards.js
@@ -203,7 +203,7 @@ const REWARDS = [
     [
         { currency: 'coins', amount: 10000 },
         { currency: 'gems', amount: 2500 },
-        { currency: 'robux', amount: 500 },
+        { item: 'gift_card_25', amount: 1 },
         { item: 'void_chest', amount: 2 },
         { item: 'discount_ticket_100', amount: 2 },
         { item: 'inf_chest', amount: 1 },


### PR DESCRIPTION
## Summary
- change level 100 reward to a $25 Giftcard and drop Robux
- define new `gift_card_25` item in the config
- show instructions on earning BP XP

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861615a6374832c8928804930538d84