### PR TITLE
Add gift card voucher item

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -388,6 +388,12 @@ const config = {
             emoji: "<a:robux:1378395622683574353>", rarityValue: 0,
             description: "A $25 gift card."
         },
+        "25giftcard": {
+            id: "25giftcard", name: "25$ Giftcard Voucher", type: "item",
+            emoji: "<a:robux:1378395622683574353>", rarityValue: 0,
+            description: "Redeem to receive a $25 gift card.",
+            expiresAfterMs: 24 * 60 * 60 * 1000
+        },
         "daily_skip_ticket": {
             id: "daily_skip_ticket", name: "Daily Skip Ticket", type: "item",
             emoji: "<:dailyskip:1387286893338693764>", rarityValue: 0,

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ const ITEM_IDS = {
     DISCOUNT_50: gameConfig.items.discount_ticket_50?.id || 'discount_ticket_50',
     DISCOUNT_100: gameConfig.items.discount_ticket_100?.id || 'discount_ticket_100',
     GIFT_CARD_25: gameConfig.items.gift_card_25?.id || 'gift_card_25',
+    GIFT_CARD_25_VOUCHER: gameConfig.items['25giftcard']?.id || '25giftcard',
 };
 
 const fs = require('node:fs').promises;

--- a/systems.js
+++ b/systems.js
@@ -1289,6 +1289,13 @@ this.db.prepare(`
             if (!takeResult) return { success: false, message: `Not enough ${itemName} to use.`};
             for (let i = 0; i < amount; i++) { this.activateCharm(userId, guildId, { charmId: itemId, source: `inventory_use_${itemId}` }); }
             return { success: true, message: `Activated ${amount}x ${itemEmoji} **${itemName}** from inventory.` };
+        } else if (itemId === '25giftcard') {
+            const takeResult = this.takeItem(userId, guildId, itemId, amount);
+            if (!takeResult) return { success: false, message: `Not enough ${itemName} to use.` };
+            for (let i = 0; i < amount; i++) {
+                this.giveItem(userId, guildId, this.gameConfig.items.gift_card_25?.id || 'gift_card_25', 1, this.itemTypes.ITEM, 'giftcard_redeem');
+            }
+            return { success: true, message: `Redeemed ${amount}x ${itemEmoji} **${itemName}**! Check your inventory for the gift card.` };
         } else if ([this.itemTypes.ITEM, this.itemTypes.JUNK, this.itemTypes.COLLECTIBLE, this.itemTypes.SPECIAL_ROLE_ITEM].includes(effectiveItemType)) {
             const takeResult = this.takeItem(userId, guildId, itemId, amount);
             if (!takeResult) return { success: false, message: `Not enough ${itemEmoji} **${itemName}** (x${amount}) to use.` };

--- a/utils/battlePassRewards.js
+++ b/utils/battlePassRewards.js
@@ -203,7 +203,7 @@ const REWARDS = [
     [
         { currency: 'coins', amount: 10000 },
         { currency: 'gems', amount: 2500 },
-        { item: 'gift_card_25', amount: 1 },
+        { item: '25giftcard', amount: 1 },
         { item: 'void_chest', amount: 2 },
         { item: 'discount_ticket_100', amount: 2 },
         { item: 'inf_chest', amount: 1 },


### PR DESCRIPTION
## Summary
- introduce a `25giftcard` item that expires after one day
- expose the new item id constant
- grant the voucher instead of the direct gift card at level 100
- redeeming the voucher gives the real gift card

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6861e78dc6e4832cbf98a8e9e63dce6e