### PR TITLE
Update level 100 reward logic

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -383,17 +383,6 @@ const config = {
             emoji: "<:rainbow100:1387285530865176687>", rarityValue: 0,
             description: "Apply a 100% discount to a shop purchase."
         },
-        "gift_card_25": {
-            id: "gift_card_25", name: "25$ Giftcard", type: "item",
-            emoji: "<a:robux:1378395622683574353>", rarityValue: 0,
-            description: "A $25 gift card."
-        },
-        "25giftcard": {
-            id: "25giftcard", name: "25$ Giftcard Voucher", type: "item",
-            emoji: "<a:robux:1378395622683574353>", rarityValue: 0,
-            description: "Redeem to receive a $25 gift card.",
-            expiresAfterMs: 24 * 60 * 60 * 1000
-        },
         "daily_skip_ticket": {
             id: "daily_skip_ticket", name: "Daily Skip Ticket", type: "item",
             emoji: "<:dailyskip:1387286893338693764>", rarityValue: 0,

--- a/systems.js
+++ b/systems.js
@@ -1286,13 +1286,6 @@ this.db.prepare(`
             if (!takeResult) return { success: false, message: `Not enough ${itemName} to use.`};
             for (let i = 0; i < amount; i++) { this.activateCharm(userId, guildId, { charmId: itemId, source: `inventory_use_${itemId}` }); }
             return { success: true, message: `Activated ${amount}x ${itemEmoji} **${itemName}** from inventory.` };
-        } else if (itemId === '25giftcard') {
-            const takeResult = this.takeItem(userId, guildId, itemId, amount);
-            if (!takeResult) return { success: false, message: `Not enough ${itemName} to use.` };
-            for (let i = 0; i < amount; i++) {
-                this.giveItem(userId, guildId, this.gameConfig.items.gift_card_25?.id || 'gift_card_25', 1, this.itemTypes.ITEM, 'giftcard_redeem');
-            }
-            return { success: true, message: `Redeemed ${amount}x ${itemEmoji} **${itemName}**! Check your inventory for the gift card.` };
         } else if ([this.itemTypes.ITEM, this.itemTypes.JUNK, this.itemTypes.COLLECTIBLE, this.itemTypes.SPECIAL_ROLE_ITEM].includes(effectiveItemType)) {
             const takeResult = this.takeItem(userId, guildId, itemId, amount);
             if (!takeResult) return { success: false, message: `Not enough ${itemEmoji} **${itemName}** (x${amount}) to use.` };

--- a/utils/battlePassRewards.js
+++ b/utils/battlePassRewards.js
@@ -203,7 +203,7 @@ const REWARDS = [
     [
         { currency: 'coins', amount: 10000 },
         { currency: 'gems', amount: 2500 },
-        { item: '25giftcard', amount: 1 },
+        { text: '$25 Gift Card' },
         { item: 'void_chest', amount: 2 },
         { item: 'discount_ticket_100', amount: 2 },
         { item: 'inf_chest', amount: 1 },


### PR DESCRIPTION
## Summary
- remove gift card item definitions and redeem logic
- adjust battle pass rewards to show a text prize and replace it with void chests after first claim
- announce first Level 100 claim in a designated channel and ping a role
- improve battle pass embed to always show three fields and support text-only rewards

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68621ebfe888832c89a54c31909f4871