### PR TITLE
Implement badge system

### DIFF
--- a/commands/award-badge.js
+++ b/commands/award-badge.js
@@ -1,0 +1,44 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const gameConfig = require('../game_config.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('award-badge')
+        .setDescription('Award a badge to a user (Owner only)')
+        .addUserOption(o => o.setName('user').setDescription('Target user').setRequired(true))
+        .addStringOption(o => {
+            o.setName('badge').setDescription('Badge ID').setRequired(true);
+            const badges = gameConfig.badges || {};
+            Object.values(badges).slice(0, 25).forEach(b => {
+                o.addChoices({ name: b.name, value: b.id });
+            });
+            return o;
+        }),
+    async execute(interaction, client) {
+        if (interaction.user.id !== '902736357766594611') {
+            return interaction.reply({ content: 'Owner only.', ephemeral: true });
+        }
+        const badgeId = interaction.options.getString('badge');
+        const targetUser = interaction.options.getUser('user');
+        const systems = client.levelSystem;
+        const badge = systems.getAllBadges()[badgeId];
+        if (!badge) {
+            return interaction.reply({ content: 'Badge not found.', ephemeral: true });
+        }
+        const result = systems.awardBadge(targetUser.id, interaction.guild.id, badgeId);
+        if (result.success) {
+            try {
+                await targetUser.send({ embeds: [
+                    new (require('discord.js').EmbedBuilder)()
+                        .setColor(0xF1C40F)
+                        .setTitle('CONGRATULATION')
+                        .setDescription(`hey ${targetUser} you have obtained ${badge.name} ${badge.emoji} badge!`)
+                        .addFields({ name: 'perk gained', value: badge.perk })
+                ] });
+            } catch {}
+            await interaction.reply({ content: `Badge awarded to ${targetUser.tag}.`, ephemeral: true });
+        } else {
+            await interaction.reply({ content: result.message || 'User already has this badge.', ephemeral: true });
+        }
+    }
+};

--- a/commands/check-badge.js
+++ b/commands/check-badge.js
@@ -1,0 +1,62 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('check-badge')
+        .setDescription('View your obtained and unobtained badges'),
+    async execute(interaction, client) {
+        const systems = client.levelSystem;
+        const allBadges = systems.getAllBadges();
+        const userId = interaction.user.id;
+        const guildId = interaction.guild.id;
+        const obtainedIds = systems.getUserBadgeIds(userId, guildId);
+        const obtainedList = Object.values(allBadges).filter(b => obtainedIds.includes(b.id));
+        const unobtainedList = Object.values(allBadges).filter(b => !obtainedIds.includes(b.id));
+        const buildEmbed = (type, page) => {
+            const list = type === 'obtained' ? obtainedList : unobtainedList;
+            const pageCount = Math.max(1, Math.ceil(list.length / 25));
+            page = Math.min(Math.max(page, 1), pageCount);
+            const embed = new EmbedBuilder()
+                .setColor(type === 'obtained' ? 0x2ecc71 : 0xe74c3c)
+                .setTitle(type === 'obtained' ? 'Obtained Badges' : 'Unobtained Badges')
+                .setDescription(`### Page ${page}/${pageCount}`);
+            const start = (page - 1) * 25;
+            for (const b of list.slice(start, start + 25)) {
+                const typeLine = b.type.includes('limited') ? `<:limites:1389227936569233458> LIMITED ${b.type.includes('unobtainable') ? '- <:nos:1389227923965476905> Unobtainable' : '- <:yess:1389227929392644218> Obtainable'}` : (b.type.includes('unobtainable') ? '<:nos:1389227923965476905> Unobtainable' : '<:yess:1389227929392644218> Obtainable');
+                embed.addFields({
+                    name: `${b.name} ${b.emoji || ''}`,
+                    value: `* Obtainment: ${b.obtainment}\n* Perk: ${b.perk}\n- ${typeLine}`,
+                    inline: false
+                });
+            }
+            embed.setFooter({ text: `You have obtained ${obtainedList.length} out of ${Object.keys(allBadges).length} badges` });
+            return { embed, pageCount, page };
+        };
+        const buildComponents = (type, page, pageCount) => {
+            const prev = new ButtonBuilder()
+                .setCustomId(`badge_goto_${type}_${page-1}`)
+                .setLabel(`⬅️ - ${page-1}`)
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(page <= 1);
+            const next = new ButtonBuilder()
+                .setCustomId(`badge_goto_${type}_${page+1}`)
+                .setLabel(`${page} - ➡️`)
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(page >= pageCount);
+            const obtainedBtn = new ButtonBuilder()
+                .setCustomId(`badge_view_obtained_${page}`)
+                .setLabel('obtained')
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(type === 'obtained');
+            const unobtainedBtn = new ButtonBuilder()
+                .setCustomId(`badge_view_unobtained_${page}`)
+                .setLabel('unobtained')
+                .setStyle(ButtonStyle.Primary)
+                .setDisabled(type === 'unobtained');
+            return [new ActionRowBuilder().addComponents(prev, obtainedBtn, unobtainedBtn, next)];
+        };
+        const { embed, pageCount } = buildEmbed('obtained', 1);
+        const components = buildComponents('obtained', 1, pageCount);
+        await interaction.reply({ embeds: [embed], components, ephemeral: false });
+    }
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -478,6 +478,18 @@ const commands = [
         default_member_permissions: PermissionsBitField.Flags.Administrator.toString()
     },
     {
+        name: 'check-badge',
+        description: 'View your obtained and unobtained badges'
+    },
+    {
+        name: 'award-badge',
+        description: 'Award a badge to a user (Owner only)',
+        options: [
+            { name: 'user', description: 'Target user', type: ApplicationCommandOptionType.User, required: true },
+            { name: 'badge', description: 'Badge ID', type: ApplicationCommandOptionType.String, required: true }
+        ]
+    },
+    {
         name: 'join-scavenger',
         description: 'Join the scavenger hunt and receive a private channel.'
     }

--- a/game_config.js
+++ b/game_config.js
@@ -389,6 +389,24 @@ const config = {
             description: "Skip the daily reward cooldown without spending gems."
         }
     },
+    badges: {
+        bp1_champion: {
+            id: "bp1_champion",
+            name: "Battle-Pass 1# Champion",
+            emoji: "<:season1c:1389126156439261264>",
+            obtainment: "Be the first to complete July 2025 Batte Pass",
+            type: "limited - obtainable",
+            perk: "increase coin by 100%, gem by 25%, xp by 1"
+        },
+        bp1_complete: {
+            id: "bp1_complete",
+            name: "Battle-Pass 1#",
+            emoji: "<:season1t:1389126139297140766>",
+            obtainment: "complete July 2025 Battle Pass",
+            type: "limited - obtainable",
+            perk: "increase coin by 20%, gem by 5%"
+        }
+    },
     directChatDropTable: [ // Robux is NOT added here as it's command/shop only
         { itemId: "nothing_drop", directDropWeight: 0.900077 },
         { itemId: "common_loot_box", directDropWeight: 0.095 },


### PR DESCRIPTION
## Summary
- add badge definitions to game config
- create database table for user badges
- add `/check-badge` and `/award-badge` commands
- show badge panels with navigation buttons
- notify users when they earn battle pass badges

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68628ec11aa8832c8cc19c50580de502