### PR TITLE
Add puzzle champion badge and emoji updates

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -385,7 +385,7 @@ const config = {
         },
         "daily_skip_ticket": {
             id: "daily_skip_ticket", name: "Daily Skip Ticket", type: "item",
-            emoji: "<:dailyskip:1387286893338693764>", rarityValue: 0,
+            emoji: "<:skipdailyticket:1389239150703673448>", rarityValue: 0,
             description: "Skip the daily reward cooldown without spending gems."
         }
     },
@@ -405,6 +405,14 @@ const config = {
             obtainment: "complete July 2025 Battle Pass",
             type: "limited - obtainable",
             perk: "increase coin by 20%, gem by 5%"
+        },
+        puzzle_champion_2025: {
+            id: "puzzle_champion_2025",
+            name: "Puzzle Champion 2025",
+            emoji: "<:pccbdage:1389237940353241098>",
+            obtainment: "Be the first to solve all puzzle in Puzzle Competiton 2025",
+            type: "limited - obtainable",
+            perk: "increase coin gain by 100%, gem by 25%, xp by 1"
         }
     },
     directChatDropTable: [ // Robux is NOT added here as it's command/shop only

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ const XP_BOOST_EMOJI = '<:sxpmulti:1384502410059317410>';
 const GEM_BOOST_EMOJI = '<:sgemmulti:1384507113048506428>';
 const DISCOUNT_BOOST_EMOJI = '<:sdiscount:1384506117895225355>';
 const GEM_CHAT_BOOST_EMOJI = '<:sultragemmulti:1384512368708423781>';
-const BATTLE_TOKEN_EMOJI = '<:battletoken:1389109195374203030>';
+const BATTLE_TOKEN_EMOJI = '<:bppoint:1389238189671321672>';
 
 const { SHOP_ITEM_TYPES } = require('./shopManager.js');
 const SHOP_DISCOUNT_IDS = ['dis10', 'dis25', 'dis50', 'dis100'];
@@ -501,7 +501,7 @@ async function buildDailyEmbed(interaction, client) {
             .setCustomId('skip_daily_ticket')
             .setLabel('Skip Reward (1 Ticket)')
             .setStyle(ButtonStyle.Secondary)
-            .setEmoji('<:dailyskip:1387286893338693764>')
+            .setEmoji('<:skipdailyticket:1389239150703673448>')
             .setDisabled(canClaim)
     );
 
@@ -2325,6 +2325,20 @@ client.on('messageCreate', async message => {
                 .setDescription(`Give it up for <@${member.id}> for completing the secret quest!`)
                 .setTimestamp();
             await announceChannel.send({ content: '@here', embeds: [embed] }).catch(() => {});
+        }
+
+        const champ = client.levelSystem.getAllBadges().puzzle_champion_2025;
+        if (champ) {
+            const res = client.levelSystem.awardBadge(member.id, message.guild.id, champ.id);
+            if (res.success) {
+                const dmEmbed = new EmbedBuilder()
+                    .setColor(0xF1C40F)
+                    .setTitle('CONGRATULATION')
+                    .setDescription(`hey <@${member.id}> you have obtained ${champ.name} ${champ.emoji} badge!`)
+                    .addFields({ name: 'perk gained', value: champ.perk });
+                await member.send({ embeds: [dmEmbed] }).catch(() => {});
+                client.levelSystem.gameConfig.badges.puzzle_champion_2025.type = 'limited - unobtainable';
+            }
         }
         PUZZLE_COMPLETED = true;
         return;


### PR DESCRIPTION
## Summary
- add Puzzle Champion 2025 badge in `game_config.js`
- update skip ticket button and item emoji
- update battle pass point emoji
- award Puzzle Champion 2025 badge when finishing the secret puzzle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686293fabb94832c80440c4844bf7084