### PR TITLE
Fix check-badge interaction reply

### DIFF
--- a/index.js
+++ b/index.js
@@ -3500,7 +3500,10 @@ module.exports = {
             }
             const unhandledCommand = client.commands.get(commandName);
             if(unhandledCommand) {
-                 if (!interaction.replied && !interaction.deferred) { await safeDeferReply(interaction, {ephemeral: true}); deferredThisInteraction = true;}
+                 if (commandName !== 'check-badge' && !interaction.replied && !interaction.deferred) {
+                     await safeDeferReply(interaction, {ephemeral: true});
+                     deferredThisInteraction = true;
+                 }
                  if (commandName === 'add-user' || commandName === 'withdraw-robux') { /* Already handled by new logic */ }
                  else { await unhandledCommand.execute(interaction, client); } // Ensure client is passed if needed by command
                  return;


### PR DESCRIPTION
## Summary
- avoid auto-deferring check-badge so it can reply normally

## Testing
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_e_6862987b3748832c98f665c31b7a4ce9