### PR TITLE
Update BP1 badge availability after pass ends

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -394,7 +394,7 @@ const config = {
             id: "bp1_champion",
             name: "Battle-Pass 1# Champion",
             emoji: "<:season1c:1389126156439261264>",
-            obtainment: "Be the first to complete July 2025 Batte Pass",
+            obtainment: "Be the first to complete July 2025 Batte Pass (unobtainable after the Battle Pass ends)",
             type: "limited - obtainable",
             perk: "increase coin by 100%, gem by 25%, xp by 1"
         },
@@ -402,7 +402,7 @@ const config = {
             id: "bp1_complete",
             name: "Battle-Pass 1#",
             emoji: "<:season1t:1389126139297140766>",
-            obtainment: "complete July 2025 Battle Pass",
+            obtainment: "complete July 2025 Battle Pass (unobtainable after the Battle Pass ends)",
             type: "limited - obtainable",
             perk: "increase coin by 20%, gem by 5%"
         },

--- a/index.js
+++ b/index.js
@@ -1172,6 +1172,25 @@ async function schedulePuzzleAnnouncement(client) {
     }
 }
 
+async function scheduleBattlePassBadgeUpdate(client) {
+    const updateBadges = () => {
+        if (!client.levelSystem) return;
+        if (Date.now() > BATTLE_PASS_END) {
+            if (client.levelSystem.gameConfig?.badges?.bp1_champion) {
+                client.levelSystem.gameConfig.badges.bp1_champion.type = 'limited - unobtainable';
+            }
+            if (client.levelSystem.gameConfig?.badges?.bp1_complete) {
+                client.levelSystem.gameConfig.badges.bp1_complete.type = 'limited - unobtainable';
+            }
+        }
+    };
+    updateBadges();
+    const delay = BATTLE_PASS_END - Date.now();
+    if (delay > 0) {
+        setTimeout(updateBadges, delay);
+    }
+}
+
 async function safeDeferReply(interaction, options = {}) {
     if (!interaction.isRepliable() || interaction.deferred || interaction.replied) return;
     try {
@@ -2229,6 +2248,7 @@ if (client.levelSystem && client.levelSystem.shopManager) {
 scheduleStreakLossCheck(client);
 scheduleDailyReadyNotifications(client);
 schedulePuzzleAnnouncement(client);
+scheduleBattlePassBadgeUpdate(client);
 
     // Config checks
     if (!LEVEL_UP_CHANNEL_ID) console.warn("[Config Check] LEVEL_UP_CHANNEL_ID not defined.");


### PR DESCRIPTION
## Summary
- add note in badge config about battle pass expiration
- schedule battle pass badge availability updates

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686299e80b90832c823a0cc708d3567a