### PR TITLE
Add perk emojis

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -396,7 +396,7 @@ const config = {
             emoji: "<:season1c:1389126156439261264>",
             obtainment: "Be the first to complete July 2025 Batte Pass (unobtainable after the Battle Pass ends)",
             type: "limited - obtainable",
-            perk: "Coin +100%, Gem +25%, XP +1"
+            perk: "<:scoinmulti:1384503519330959380> Coin +100%, <:sgemmulti:1384507113048506428> Gem +25%, <:sxpmulti:1384502410059317410> XP +1"
         },
         bp1_complete: {
             id: "bp1_complete",
@@ -404,7 +404,7 @@ const config = {
             emoji: "<:season1t:1389126139297140766>",
             obtainment: "complete July 2025 Battle Pass (unobtainable after the Battle Pass ends)",
             type: "limited - obtainable",
-            perk: "Coin +20%, Gem +5%"
+            perk: "<:scoinmulti:1384503519330959380> Coin +20%, <:sgemmulti:1384507113048506428> Gem +5%"
         },
         puzzle_champion_2025: {
             id: "puzzle_champion_2025",
@@ -412,7 +412,7 @@ const config = {
             emoji: "<:pccbdage:1389237940353241098>",
             obtainment: "Be the first to solve all puzzle in Puzzle Competiton 2025",
             type: "limited - obtainable",
-            perk: "Coin +100%, Gem +25%, XP +1"
+            perk: "<:scoinmulti:1384503519330959380> Coin +100%, <:sgemmulti:1384507113048506428> Gem +25%, <:sxpmulti:1384502410059317410> XP +1"
         }
     },
     directChatDropTable: [ // Robux is NOT added here as it's command/shop only


### PR DESCRIPTION
## Summary
- update game badge perk text to include multiplier emojis for coin, gem and xp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a4584074832c94b5950b2e1dda81