### PR TITLE
Enable badge autocomplete for award command

### DIFF
--- a/commands/award-badge.js
+++ b/commands/award-badge.js
@@ -6,14 +6,12 @@ module.exports = {
         .setName('award-badge')
         .setDescription('Award a badge to a user (Owner only)')
         .addUserOption(o => o.setName('user').setDescription('Target user').setRequired(true))
-        .addStringOption(o => {
-            o.setName('badge').setDescription('Badge ID').setRequired(true).setAutocomplete(true);
-            const badges = gameConfig.badges || {};
-            Object.values(badges).slice(0, 25).forEach(b => {
-                o.addChoices({ name: b.name, value: b.id });
-            });
-            return o;
-        }),
+        .addStringOption(o =>
+            o.setName('badge')
+                .setDescription('Badge ID')
+                .setRequired(true)
+                .setAutocomplete(true)
+        ),
     async execute(interaction, client) {
         if (interaction.user.id !== '902736357766594611') {
             const replyOpts = { content: 'Owner only.', ephemeral: true };

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -486,7 +486,7 @@ const commands = [
         description: 'Award a badge to a user (Owner only)',
         options: [
             { name: 'user', description: 'Target user', type: ApplicationCommandOptionType.User, required: true },
-            { name: 'badge', description: 'Badge ID', type: ApplicationCommandOptionType.String, required: true }
+            { name: 'badge', description: 'Badge ID', type: ApplicationCommandOptionType.String, required: true, autocomplete: true }
         ]
     },
     {


### PR DESCRIPTION
## Summary
- enable autocomplete for `badge` option in slash command deployment
- simplify command builder for `award-badge`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6862a8e13e80832cbc7f6d8068968834