### PR TITLE
Fix discount ticket emoji across bot

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -370,7 +370,7 @@ const config = {
         },
         "discount_ticket_25": {
             id: "discount_ticket_25", name: "25% Discount Ticket", type: "item",
-            emoji: "<silver25:1387285550997831720>", rarityValue: 35000,
+            emoji: "<:silver25:1387285550997831720>", rarityValue: 35000,
             description: "Apply a 25% discount to a shop purchase."
         },
         "discount_ticket_50": {


### PR DESCRIPTION
## Summary
- correct 25% discount ticket emoji syntax

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863e8d07af4832c83bf5dc0e656f6e0