### PR TITLE
Implement battle pass rebirth and nerf VC BP gain

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -1613,7 +1613,8 @@ this.db.prepare(`
                 let battlePassPoints = 0;
                 if (this.client && this.client.battlePass) {
                     const minutes = VOICE_ACTIVITY_INTERVAL_MS / 60000;
-                    const pts = (Math.floor(Math.random() * 31) + 30) * minutes;
+                    const basePts = (Math.floor(Math.random() * 31) + 30) * minutes;
+                    const pts = Math.floor(basePts / 5);
                     this.client.battlePass.addPoints(userId, guildId, pts);
                     battlePassPoints = pts;
                 }


### PR DESCRIPTION
## Summary
- reduce battle pass XP gain from voice chat
- add rebirth system after level 100
- multiply rewards based on rebirth count and scale BP requirements
- show rebirths in battle pass UI and handle rebirth interactions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866c6b661d4832cb2ab228b7da2c729