### PR TITLE
Reduce BP level requirements

### DIFF
--- a/utils/battlePassManager.js
+++ b/utils/battlePassManager.js
@@ -72,7 +72,8 @@ class BattlePassManager {
         else if (next <= 60) base = 40 * next;
         else base = 60 * next;
         const mult = Math.pow(1.35, rebirths);
-        return Math.ceil(base * mult);
+        // Nerf level requirements by 50%
+        return Math.ceil(base * mult * 0.5);
     }
     pointsForLevel(level, rebirths = 0) {
         let total = 0;


### PR DESCRIPTION
## Summary
- nerf battle pass requirements by halving XP needed for each level

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866cac7ae3c832cb8747cee5ffebd0f