### PR TITLE
Implement slots machine game

### DIFF
--- a/commands/slots.js
+++ b/commands/slots.js
@@ -1,0 +1,11 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('slots')
+        .setDescription('Play the slots machine game.'),
+    async execute(interaction) {
+        await interaction.reply({ content: 'Starting slots...', ephemeral: false });
+        // Actual logic handled in index.js
+    },
+};


### PR DESCRIPTION
## Summary
- add `/slots` command stub
- implement slot machine logic in interaction handler
- track bets and cooldowns for slots
- send alerts for jackpot and luxury wins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68679c029004832caea08b0971673507