### PR TITLE
Add slots slash command

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -185,7 +185,7 @@ const commands = [
         name: 'inventory',
         description: 'Access your inventory, balance, and charms.',
     },
-     {
+    {
         name: 'use-item',
         description: 'Use an item from your inventory.',
         options: [
@@ -204,6 +204,10 @@ const commands = [
                 minValue: 1,
             }
         ]
+    },
+    {
+        name: 'slots',
+        description: 'Play the slots machine game.'
     },
     {
         name: 'database',


### PR DESCRIPTION
## Summary
- register `/slots` in deployCommands.js so it appears as a slash command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6867a418318c832cb58015d2f3f4451a