### PR TITLE
Implement persistent voice chat reward tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -2255,6 +2255,11 @@ client.once('ready', async c => {
         console.log('[Startup] Recalculated luck bonuses for all users.');
     }
 
+    if (client.levelSystem && typeof client.levelSystem.resumeVoiceSessions === 'function') {
+        await client.levelSystem.resumeVoiceSessions();
+        console.log('[Startup] Resumed voice sessions.');
+    }
+
     console.log('Attempting to load and restore previous giveaway states...');
     const { activeGiveaways: loadedActiveGiveaways, giveawaySetups: loadedGiveawaySetups } = await loadGiveaways();
 
@@ -5633,8 +5638,8 @@ client.on('guildMemberRemove', async member => {
         // Clear from active voice users
         const voiceStateKey = `${member.id}-${member.guild.id}`;
         if (client.levelSystem.activeVoiceUsers.has(voiceStateKey)) {
-            client.levelSystem.activeVoiceUsers.delete(voiceStateKey);
-             console.log(`[GuildMemberRemove] Removed ${member.user.tag} from active voice users upon leaving.`);
+            await client.levelSystem._finalizeVoiceSession(member.id, member.guild.id, member, WEEKEND_MULTIPLIERS);
+            console.log(`[GuildMemberRemove] Processed voice session for ${member.user.tag} upon leaving.`);
         }
 
         // New: Clean up user management sessions if the admin leaves or target user leaves


### PR DESCRIPTION
## Summary
- track active voice sessions in the database
- award XP and battle pass points based on total voice time when users leave
- restore and finalize voice sessions on bot restart
- process remaining voice time when members leave the server

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68680a092c18832caa3f9c7453f24da7