### PR TITLE
Add /add-daily-streak admin command

### DIFF
--- a/commands/add-daily-streak.js
+++ b/commands/add-daily-streak.js
@@ -1,0 +1,21 @@
+// commands/add-daily-streak.js
+const { SlashCommandBuilder, PermissionsBitField, ApplicationCommandOptionType } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('add-daily-streak')
+        .setDescription('Increase a user\'s daily streak (Staff Only).')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('The user to modify streak for.')
+                .setRequired(true))
+        .addIntegerOption(option =>
+            option.setName('amount')
+                .setDescription('Number of days to add to their streak.')
+                .setRequired(true))
+        .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
+    async execute(interaction) {
+        // Command logic handled centrally in index.js
+        await interaction.reply({ content: 'Processing add-daily-streak command...', ephemeral: true });
+    },
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -270,6 +270,15 @@ const commands = [
         default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
     },
     {
+        name: 'add-daily-streak',
+        description: 'Increase a user\'s daily streak (Staff Only).',
+        options: [
+            { name: 'user', description: 'The user to modify streak for.', type: ApplicationCommandOptionType.User, required: true },
+            { name: 'amount', description: 'Number of streak days to add.', type: ApplicationCommandOptionType.Integer, required: true }
+        ],
+        default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
+    },
+    {
         name: 'give-item',
         description: 'Give an item to a user (Staff Only).',
         options: [

--- a/index.js
+++ b/index.js
@@ -2855,7 +2855,7 @@ client.on('interactionCreate', async interaction => {
                 } catch (error) { console.error('[AdminResetData Command] Critical error:', error); await sendInteractionError(interaction, 'A critical error occurred while attempting to reset data.', true, deferredThisInteraction); }
                 return;
             }
-            if (commandName === 'add-xp' || commandName === 'add-level' || commandName === 'set-level' || commandName === 'add-coin' || commandName === 'add-gem' || commandName === 'add-robux') {
+            if (commandName === 'add-xp' || commandName === 'add-level' || commandName === 'set-level' || commandName === 'add-coin' || commandName === 'add-gem' || commandName === 'add-robux' || commandName === 'add-daily-streak') {
                 if (!isStaff()) return sendInteractionError(interaction, "You don't have permission.", true, false);
                 if (!interaction.replied && !interaction.deferred) { await safeDeferReply(interaction, { ephemeral: true }); deferredThisInteraction = true; }
                 try {
@@ -2899,6 +2899,11 @@ client.on('interactionCreate', async interaction => {
                         const robuxResult = client.levelSystem.addRobux(targetUser.id, interaction.guildId, amount, "admin_command");
                         const robuxEmoji = client.levelSystem.robuxEmoji || DEFAULT_ROBUX_EMOJI_FALLBACK;
                         await safeEditReply(interaction, { content: `✅ Added ${robuxResult.added} ${robuxEmoji} to ${targetUser}. New balance: ${robuxResult.newBalance}.` });
+                    }
+                    else if (commandName === 'add-daily-streak') {
+                        if (amount === null || amount <= 0) return sendInteractionError(interaction, 'Amount must be a positive integer.', true, deferredThisInteraction);
+                        const streakResult = client.levelSystem.addDailyStreak(targetUser.id, interaction.guildId, amount);
+                        await safeEditReply(interaction, { content: `✅ Increased ${targetUser}'s daily streak from ${streakResult.oldStreak} to ${streakResult.newStreak}.` });
                     }
                 } catch (error) { console.error(`[Admin Modify Stat Error - ${commandName}]`, error); await sendInteractionError(interaction, 'Failed to modify user stat.', true, deferredThisInteraction); }
                 return;

--- a/systems.js
+++ b/systems.js
@@ -1962,6 +1962,23 @@ this.db.prepare(`
         this.updateUserLuckBonus(userId, guildId);
     }
 
+    addDailyStreak(userId, guildId, amount) {
+        if (!Number.isInteger(amount) || amount === 0) {
+            return { success: false, message: 'Amount must be a non-zero integer.' };
+        }
+        const user = this.getUser(userId, guildId);
+        const oldStreak = user.dailyStreak || 0;
+        let newStreak = oldStreak + amount;
+        if (newStreak < 0) newStreak = 0;
+        this.updateUser(userId, guildId, {
+            dailyStreak: newStreak,
+            lostStreak: 0,
+            lostStreakTimestamp: 0,
+        });
+        this.updateUserLuckBonus(userId, guildId);
+        return { success: true, oldStreak, newStreak };
+    }
+
     attemptStreakRestore(userId, guildId, oldStreakFromButton) {
         const user = this.getUser(userId, guildId);
         if (user.lostStreak === 0) {


### PR DESCRIPTION
## Summary
- allow admins to increment a user's daily streak with new `/add-daily-streak` slash command
- support streak modification in the systems manager
- handle new command in interaction router
- expose command in deployment script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e7f094724832ca133dd53fe83b3ca