### PR TITLE
Add Build Battle Champion badge

### DIFF
--- a/commands/check-badge.js
+++ b/commands/check-badge.js
@@ -26,7 +26,7 @@ module.exports = {
                 .setDescription(`### Page ${page}/${pageCount}`);
             const start = (page - 1) * 25;
             for (const b of list.slice(start, start + 25)) {
-                const typeLine = b.type.includes('limited') ? `<:limites:1389227936569233458> LIMITED ${b.type.includes('unobtainable') ? '- <:nos:1389227923965476905> Unobtainable' : '- <:yess:1389227929392644218> Obtainable'}` : (b.type.includes('unobtainable') ? '<:nos:1389227923965476905> Unobtainable' : '<:yess:1389227929392644218> Obtainable');
+                const typeLine = b.type.includes('limited') ? `<:limited:1392780276232355931> LIMITED ${b.type.includes('unobtainable') ? '- <:nos:1389227923965476905> Unobtainable' : '- <:yess:1389227929392644218> Obtainable'}` : (b.type.includes('unobtainable') ? '<:nos:1389227923965476905> Unobtainable' : '<:yess:1389227929392644218> Obtainable');
 
                 const perkWithEmojis = (b.perk || '')
                     .replace(/\bcoin\b/gi, `coin ${COIN_BOOST_EMOJI}`)

--- a/game_config.js
+++ b/game_config.js
@@ -398,6 +398,15 @@ const config = {
             type: "limited - unobtainable",
             perk: "<:scoinmulti:1384503519330959380> Coin +100%, <:sgemmulti:1384507113048506428> Gem +25%, <:sxpmulti:1384502410059317410> XP +1",
             boosts: { coinMultiplier: 2.0, gemMultiplier: 1.25, xpPerMessage: 1 }
+        },
+        build_battle_champion_1: {
+            id: "build_battle_champion_1",
+            name: "Build Battle Champion 1",
+            emoji: "🏆",
+            obtainment: "Be the top 2 winning the Build Battle 2025 - August",
+            type: "limited - obtainable",
+            perk: "<:scoinmulti:1384503519330959380> Coin +100%, <:sultragemmulti:1384512368708423781> Gem +1/msg, <:sxpmulti:1384502410059317410> XP +3/msg",
+            boosts: { coinMultiplier: 2.0, gemPerMessage: 1, xpPerMessage: 3 }
         }
     },
     directChatDropTable: [ // Robux is NOT added here as it's command/shop only

--- a/index.js
+++ b/index.js
@@ -1676,7 +1676,7 @@ function buildBadgeEmbed(userId, guildId, client, view = 'obtained', page = 1) {
         .setDescription(`### Page ${page}/${pageCount}`);
     const start = (page - 1) * 25;
     for (const b of list.slice(start, start + 25)) {
-        const typeLine = b.type.includes('limited') ? `<:limites:1389227936569233458> LIMITED ${b.type.includes('unobtainable') ? '- <:nos:1389227923965476905> Unobtainable' : '- <:yess:1389227929392644218> Obtainable'}` : (b.type.includes('unobtainable') ? '<:nos:1389227923965476905> Unobtainable' : '<:yess:1389227929392644218> Obtainable');
+        const typeLine = b.type.includes('limited') ? `<:limited:1392780276232355931> LIMITED ${b.type.includes('unobtainable') ? '- <:nos:1389227923965476905> Unobtainable' : '- <:yess:1389227929392644218> Obtainable'}` : (b.type.includes('unobtainable') ? '<:nos:1389227923965476905> Unobtainable' : '<:yess:1389227929392644218> Obtainable');
         embed.addFields({ name: `${b.name} ${b.emoji || ''}`, value: `* Obtainment: ${b.obtainment}\n* Perk: ${b.perk}\n- ${typeLine}` });
     }
     embed.setFooter({ text: `You have obtained ${obtainedList.length} out of ${Object.keys(allBadges).length} badges` });


### PR DESCRIPTION
## Summary
- add new badge Build Battle Champion 1 with perks
- update limited badge indicator emoji
- use gem/message emoji for badge perks

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f76464748832c9c05ede9338c7250