### PR TITLE
Implement build submission modal

### DIFF
--- a/commands/submit-ticket.js
+++ b/commands/submit-ticket.js
@@ -4,9 +4,9 @@ const { SlashCommandBuilder } = require('discord.js');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('submit-ticket')
-        .setDescription('Create a private build submission channel.'),
+        .setDescription('Submit your build for review.'),
     async execute(interaction) {
         // Actual logic handled in index.js
-        await interaction.reply({ content: 'Creating your build channel...', ephemeral: true });
+        await interaction.reply({ content: 'Opening submission form...', ephemeral: true });
     },
 };


### PR DESCRIPTION
## Summary
- add constant for form verification text
- add modal form to `/submit-ticket` command
- create channel and post embed when form submitted
- tweak `commands/submit-ticket` description and message

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e30d14c832c9739436cb9a83524