### PR TITLE
Add market embed command

### DIFF
--- a/commands/market.js
+++ b/commands/market.js
@@ -1,0 +1,10 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('market')
+        .setDescription('Posts the fishing market embed to the designated channel.'),
+    async execute(interaction) {
+        await interaction.reply({ content: 'Posting market info...', ephemeral: true });
+    },
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -515,6 +515,10 @@ const commands = [
         ]
     },
     {
+        name: 'market',
+        description: 'Post the fishing market embed to a fixed channel.'
+    },
+    {
         name: 'submit-ticket',
         description: 'Create a private build submission channel.'
     }

--- a/index.js
+++ b/index.js
@@ -361,6 +361,8 @@ const SLOT_LUCK_BOOST_DURATION_MS = 5 * 60 * 1000;
 const RARE_SLOT_IDS = ['lucky7','diamond_gem','triple_bar','double_bar','single_bar','lucky_clover'];
 const SLOTS_COOLDOWN_MS = 10 * 60 * 1000;
 
+let marketEmbedSent = false;
+
 const SLOT_SYMBOLS = [
     { id: 'lucky7', emoji: '<:slucky7:1390578652118388796>', chance: 0.01, payout: 1000 },
     { id: 'diamond_gem', emoji: '<:sdiamond:1390578741335560235>', chance: 0.02, payout: 500 },
@@ -3036,6 +3038,21 @@ module.exports = {
                     }
                 } catch (shopError) { console.error(`[Shop Command] Error:`, shopError); await sendInteractionError(interaction, "Error displaying shop.", true, deferredThisInteraction); }
                 return;
+            }
+            if (commandName === 'market') {
+                if (marketEmbedSent) {
+                    return interaction.reply({ content: 'Market embed already sent.', ephemeral: true });
+                }
+                const marketChannel = await client.channels.fetch('1393515441296773191').catch(() => null);
+                if (!marketChannel || !marketChannel.isTextBased()) {
+                    return sendInteractionError(interaction, 'Market channel not found.', true, false);
+                }
+                const embed = new EmbedBuilder()
+                    .setTitle('Fishing Market')
+                    .setDescription('The market feature is not available yet.');
+                await marketChannel.send({ embeds: [embed] });
+                marketEmbedSent = true;
+                return interaction.reply({ content: 'Market embed sent!', ephemeral: true });
             }
             if (commandName === 'inventory') {
                 if (!interaction.replied && !interaction.deferred) { await safeDeferReply(interaction, { ephemeral: false }); deferredThisInteraction = true; }


### PR DESCRIPTION
## Summary
- add `/market` slash command that posts a single embed to a fixed channel
- register the new command

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6872227d07fc832c81d1a957800738ed