### PR TITLE
Remove obsolete /market command

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -515,10 +515,6 @@ const commands = [
         ]
     },
     {
-        name: 'market',
-        description: 'Post the fishing market embed to a fixed channel.'
-    },
-    {
         name: 'submit-ticket',
         description: 'Create a private build submission channel.'
     }


### PR DESCRIPTION
## Summary
- delete /market from the command deployment list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68722ede9a2c832c92af085200dab0e5