### PR TITLE
Implement fishing session and fix fish dollar earnings

### DIFF
--- a/systems.js
+++ b/systems.js
@@ -476,12 +476,14 @@ class SystemsManager {
         if (amount === 0) return { success: false, added: 0, newBalance: this.getBalance(userId, guildId).fishDollars, reason: "Amount was zero." };
 
         const user = this.getUser(userId, guildId);
-        let finalAmount = Math.round(amount);
-        let newBal = user.fishDollars + finalAmount;
+        let finalAmount = parseFloat(amount);
+        if (isNaN(finalAmount)) finalAmount = 0;
+        let newBal = (parseFloat(user.fishDollars) || 0) + finalAmount;
         let actualAdded = finalAmount;
 
         if (newBal < 0) { actualAdded = -user.fishDollars; newBal = 0; }
 
+        newBal = Math.round(newBal * 100) / 100;
         this.updateUser(userId, guildId, { fishDollars: newBal });
         return { success: true, added: actualAdded, newBalance: newBal };
     }


### PR DESCRIPTION
## Summary
- preserve decimals when adding fish dollars
- add constants and helper functions for fishing mini-game
- implement interactive fishing start, wait, and reel flow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68723a0e95d4832cabdd817a731d0038