### PR TITLE
Add fish market embed to shop and rarity colors

### DIFF
--- a/commands/fish-store.js
+++ b/commands/fish-store.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
+const { buildFishMarketEmbed } = require('../utils/fishMarketNotifier');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -19,7 +20,11 @@ module.exports = {
             new ButtonBuilder().setCustomId('buy_bait').setLabel('Buy').setStyle(ButtonStyle.Primary)
         );
         const channel = await interaction.client.channels.fetch('1393515441296773191').catch(()=>null);
-        if (channel && channel.isTextBased()) await channel.send({ embeds:[embed], components:[row] }).catch(()=>{});
+        if (channel && channel.isTextBased()) {
+            await channel.send({ embeds:[embed], components:[row] }).catch(()=>{});
+            const market = buildFishMarketEmbed();
+            await channel.send({ embeds:[market.embed], components:[market.row] }).catch(()=>{});
+        }
         await interaction.reply({ content:'Fish shop sent.', ephemeral:true });
     }
 };

--- a/index.js
+++ b/index.js
@@ -159,6 +159,15 @@ const FISH_GAME_BAR_POINTS = 100;
 const FISH_GAME_BAR_SEGMENT = 5; // each segment worth 5 points
 const FISH_BUTTON_COUNTS = { common:4, uncommon:6, rare:10, epic:14, legendary:18, mythical:20, secret:25 };
 const FISH_OTHER_EMOJIS = ['🌀','🔵','💙','💎','🐋','🧿','🌊','🔹','💤','❄️','🐬','💧','🪼','💦','🧊','🪬','🌎','➡️','⚓','🫧','🦋','💠'];
+const FISH_RARITY_COLORS = {
+    Common: '#FFFFFF',
+    Uncommon: '#75FF75',
+    Rare: '#94CAFF',
+    Epic: '#FF94FF',
+    Legendary: '#FFFF00',
+    Mythical: '#FF4D00',
+    Secret: '#B700FF'
+};
 
 const BANK_MAXED_ROLE_ID = '1380872298143416340';
 
@@ -537,11 +546,12 @@ function buildFishingBiteEmbed(fish, rod, lostDur, bar = '▒'.repeat(20), endTi
         `* ${rod.emoji} **Tier ${rod.tier} fishing rod.**`,
         `-# ** 🛡️ Durability:** ${rod.durability - lostDur} <:pixelheart:1391070636876759121> ` + (lostDur ? `\`-${lostDur}\`` : '')
     ].join('\n');
+    const color = FISH_RARITY_COLORS[fish.rarity] || '#ffffff';
     return new EmbedBuilder()
         .setAuthor({ name: 'FISHING' })
         .setTitle('A fish bite your rod!')
         .addFields({ name: 'Tool', value: valueLines, inline: false })
-        .setColor('#ffffff')
+        .setColor(color)
         .setThumbnail('https://i.ibb.co/SwDkjVjG/the-spinning-fish.gif')
         .setDescription([`### Reel it in!`, bar, `-# fail <t:${Math.floor(endTimeMs/1000)}:R>`].join('\n'));
 }
@@ -574,6 +584,7 @@ function buildFishingSuccessEmbed(fish, rod, dLoss, bLoss) {
         `* ✨ Rarity: ${fish.rarity}`,
         `* 🆔 Fish ID: \`${fish.id}\``
     ];
+    const color = FISH_RARITY_COLORS[fish.rarity] || '#00ff00';
     return new EmbedBuilder()
         .setAuthor({ name: 'FISHING' })
         .setTitle(`You have caught ${fish.name} ${fish.emoji}!`)
@@ -581,7 +592,7 @@ function buildFishingSuccessEmbed(fish, rod, dLoss, bLoss) {
             { name: 'Tool', value: toolLines, inline: false },
             { name: 'Lost', value: `* You lost ${bLoss} bait`, inline: false }
         )
-        .setColor('#00ff00')
+        .setColor(color)
         .setThumbnail('https://i.ibb.co/SwDkjVjG/the-spinning-fish.gif')
         .setDescription(desc.join('\n'));
 }

--- a/utils/fishMarketNotifier.js
+++ b/utils/fishMarketNotifier.js
@@ -19,7 +19,7 @@ async function saveData(data) {
   await fs.writeFile(DATA_FILE, JSON.stringify(data, null, 2));
 }
 
-function buildEmbed() {
+function buildFishMarketEmbed() {
   const embed = new EmbedBuilder()
     .setAuthor({ name: 'FISH MARKET' })
     .setColor('#ffffff')
@@ -41,7 +41,7 @@ async function initFishMarket(client) {
     const msg = await channel.messages.fetch(data.messageId).catch(() => null);
     if (msg) return;
   }
-  const { embed, row } = buildEmbed();
+  const { embed, row } = buildFishMarketEmbed();
   const sent = await channel.send({ embeds: [embed], components: [row] }).catch(() => null);
   if (sent) {
     data.messageId = sent.id;
@@ -49,4 +49,4 @@ async function initFishMarket(client) {
   }
 }
 
-module.exports = { initFishMarket };
+module.exports = { initFishMarket, buildFishMarketEmbed };


### PR DESCRIPTION
## Summary
- show fish market message after the fish store embed
- export `buildFishMarketEmbed` utility
- color fishing embeds based on fish rarity

## Testing
- `npm test`
- `node -c index.js`

------
https://chatgpt.com/codex/tasks/task_e_6872459111ac832cb0fad736363b77e4