### PR TITLE
Update fish store embed channel

### DIFF
--- a/commands/fish-store.js
+++ b/commands/fish-store.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder, EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
 const { buildFishMarketEmbed } = require('../utils/fishMarketNotifier');
 
+const FISH_STORE_CHANNEL_ID = '1393515441296773191';
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('fish-store')
@@ -19,7 +21,7 @@ module.exports = {
             new ButtonBuilder().setCustomId('buy_fishrod').setLabel('Buy').setStyle(ButtonStyle.Primary),
             new ButtonBuilder().setCustomId('buy_bait').setLabel('Buy').setStyle(ButtonStyle.Primary)
         );
-        const channel = await interaction.client.channels.fetch('1393515441296773191').catch(()=>null);
+        const channel = await interaction.client.channels.fetch(FISH_STORE_CHANNEL_ID).catch(() => null);
         if (channel && channel.isTextBased()) {
             await channel.send({ embeds:[embed], components:[row] }).catch(()=>{});
             const market = buildFishMarketEmbed();

--- a/utils/fishMarketNotifier.js
+++ b/utils/fishMarketNotifier.js
@@ -3,7 +3,7 @@ const path = require('node:path');
 const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 
 const DATA_FILE = path.join(__dirname, '../data/fishMarketMessage.json');
-const CHANNEL_ID = '1393515441296773191';
+const FISH_STORE_CHANNEL_ID = '1393515441296773191';
 
 async function loadData() {
   try {
@@ -35,7 +35,7 @@ function buildFishMarketEmbed() {
 
 async function initFishMarket(client) {
   const data = await loadData();
-  const channel = await client.channels.fetch(CHANNEL_ID).catch(() => null);
+  const channel = await client.channels.fetch(FISH_STORE_CHANNEL_ID).catch(() => null);
   if (!channel || !channel.isTextBased()) return;
   if (data.messageId) {
     const msg = await channel.messages.fetch(data.messageId).catch(() => null);


### PR DESCRIPTION
## Summary
- ensure fish store embed messages are always sent to the designated channel
- use the same constant in fish market notifier

## Testing
- `node --check commands/fish-store.js`
- `node --check utils/fishMarketNotifier.js`


------
https://chatgpt.com/codex/tasks/task_e_687247f7fe2c832ca160e9634a6e3ce6