### PR TITLE
Fix fishing missing-gear alert placement

### DIFF
--- a/index.js
+++ b/index.js
@@ -3420,7 +3420,7 @@ module.exports = {
                     const rodConfig = rodItem.itemId ? client.levelSystem.gameConfig.items[rodItem.itemId] : null;
                     const rodInfo = rodConfig ? { emoji: rodConfig.emoji || '🎣', power: rodConfig.power || 1, durability: rodItem.quantity || rodConfig.durability || 10, tier: (rodConfig.name && rodConfig.name.match(/(\d+)/)) ? RegExp.$1 : 1 } : null;
                     const embed = buildFishingStartEmbed(rodInfo, baitCount, alertMsg);
-                    await interaction.reply({ content: alertMsg, embeds: [embed], ephemeral: false });
+                    await interaction.reply({ embeds: [embed], ephemeral: false });
                     return;
                 }
                 const rodConfig = rodItem.itemId ? client.levelSystem.gameConfig.items[rodItem.itemId] : null;


### PR DESCRIPTION
## Summary
- remove outside message for missing fishing rod or bait so alert text appears only inside the embed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687390fd3e54832cb157fd9456457cb0