### PR TITLE
Fix fish-index reply after deferred interaction

### DIFF
--- a/commands/fish-index.js
+++ b/commands/fish-index.js
@@ -43,7 +43,22 @@ module.exports = {
         );
         const select = new StringSelectMenuBuilder().setCustomId('fish_index_filter').setPlaceholder('choose rarity').addOptions(rarities.map(r => ({ label: r, value: r })));
         const row2 = new ActionRowBuilder().addComponents(select);
-        const sent = await interaction.reply({ embeds: [embed], components: [row, row2], fetchReply: true, ephemeral: false });
-        client.fishIndexSessions.set(sent.id, { userId: interaction.user.id, guildId: interaction.guild.id, page, rarity: null });
+        const replyOpts = {
+            embeds: [embed],
+            components: [row, row2],
+            fetchReply: true,
+            ephemeral: false,
+        };
+
+        const sent = interaction.deferred || interaction.replied
+            ? await interaction.editReply(replyOpts)
+            : await interaction.reply(replyOpts);
+
+        client.fishIndexSessions.set(sent.id, {
+            userId: interaction.user.id,
+            guildId: interaction.guild.id,
+            page,
+            rarity: null,
+        });
     }
 };


### PR DESCRIPTION
## Summary
- avoid replying twice in `fish-index` by checking if the interaction was deferred

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739717bacc832c823d03382c867eaa