### PR TITLE
Reset fish timer on button press

### DIFF
--- a/index.js
+++ b/index.js
@@ -6162,6 +6162,12 @@ module.exports = {
                 }
                 session.fishIndex = Math.floor(Math.random()*session.buttonCount);
                 updateFishingMessage(key);
+                // Reset the 5s move timer whenever a button is pressed
+                if (session.moveInterval) clearInterval(session.moveInterval);
+                session.moveInterval = setInterval(() => {
+                    session.fishIndex = Math.floor(Math.random() * session.buttonCount);
+                    updateFishingMessage(key);
+                }, 5000);
                 fishingSessions.set(key, session);
                 return;
             }


### PR DESCRIPTION
## Summary
- allow resetting fish move timer by clearing and restarting the interval when a fishing game button is clicked

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739dc9a7a0832c9080a815a6d9b5ec