### PR TITLE
Fix fish index data loading and persistence

### DIFF
--- a/index.js
+++ b/index.js
@@ -6089,7 +6089,11 @@ module.exports = {
                     const value = known ? `Rarity: ${fish.rarity}\nHighest Weight: ${discovered.get(fish.name).toFixed(2)}` : '???';
                     embed.addFields({ name, value, inline: false });
                 }
-                const rarities = [...new Set(interaction.client.fishData.map(f => f.rarity))];
+                const rarities = [...new Set(
+                    interaction.client.fishData
+                        .map(f => f.rarity)
+                        .filter(r => typeof r === 'string' && r.trim())
+                )];
                 const row = new ActionRowBuilder().addComponents(
                     new ButtonBuilder().setCustomId('fish_index_prev').setEmoji('⬅️').setStyle(ButtonStyle.Primary).setDisabled(page <= 1),
                     new ButtonBuilder().setCustomId('fish_index_next').setEmoji('➡️').setStyle(ButtonStyle.Primary).setDisabled(page >= pageCount)
@@ -6415,4 +6419,12 @@ process.on('unhandledRejection', async (reason) => {
 process.on('uncaughtException', async (err) => {
     console.error('Uncaught Exception:', err);
     await logToBotLogChannel(`Uncaught Exception: ${err.message}`).catch(()=>{});
+});
+
+['SIGINT', 'SIGTERM'].forEach(sig => {
+    process.on(sig, () => {
+        console.log(`Received ${sig}, saving fish data...`);
+        persistFishData();
+        setTimeout(() => process.exit(0), 100);
+    });
 });

--- a/utils/fishDataLoader.js
+++ b/utils/fishDataLoader.js
@@ -27,19 +27,21 @@ function loadFishData(xlsxPath) {
             if (/t="s"/.test(attrs)) val = strings[parseInt(val)];
             row[col] = val ? htmlDecode(val) : val;
         }
-        data.push({
-            name: row.A,
-            rarity: row.C,
-            springChance: parseFloat(row.D) || 0,
-            summerChance: parseFloat(row.E) || 0,
-            autumnChance: parseFloat(row.F) || 0,
-            winterChance: parseFloat(row.G) || 0,
-            minWeight: parseFloat(row.J) || 0,
-            maxWeight: parseFloat(row.K) || 0,
-            durabilityLoss: parseFloat(row.M) || 0,
-            powerReq: parseFloat(row.N) || 0,
-            emoji: row.O
-        });
+        if (row.A) {
+            data.push({
+                name: row.A,
+                rarity: row.C,
+                springChance: parseFloat(row.D) || 0,
+                summerChance: parseFloat(row.E) || 0,
+                autumnChance: parseFloat(row.F) || 0,
+                winterChance: parseFloat(row.G) || 0,
+                minWeight: parseFloat(row.J) || 0,
+                maxWeight: parseFloat(row.K) || 0,
+                durabilityLoss: parseFloat(row.M) || 0,
+                powerReq: parseFloat(row.N) || 0,
+                emoji: row.O
+            });
+        }
     }
     return data;
 }


### PR DESCRIPTION
## Summary
- skip blank entries when loading fish data
- filter invalid rarities when paginating fish index
- save fish data on SIGINT/SIGTERM

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873bf3724a4832caa8496456d22d36f