### PR TITLE
Fix fishing rod persistence

### DIFF
--- a/index.js
+++ b/index.js
@@ -349,12 +349,6 @@ try {
         process.exit(1);
     }
     console.log("[SystemsManager & ShopManager] Initialized successfully.");
-    try {
-        client.levelSystem.removeItemFromAllUsers('fishing_rod%', true);
-        console.log('[FishStore] Removed existing fishing rods from all user inventories.');
-    } catch (remErr) {
-        console.error('[FishStore] Failed to purge fishing rods:', remErr.message);
-    }
 } catch (e) {
     console.error("CRITICAL: Error initializing SystemsManager. Exiting.", e);
     process.exit(1);


### PR DESCRIPTION
## Summary
- stop deleting fishing rods on every startup so user inventories persist

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6873c19f90e8832c89517671f48eda66