### PR TITLE
Add weather and event start commands

### DIFF
--- a/commands/start-event.js
+++ b/commands/start-event.js
@@ -1,0 +1,31 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { startBlossom } = require('../utils/weatherManager');
+const { initBuildBattleEvent } = require('../buildBattleEvent');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('start-event')
+        .setDescription('Start a special event (Staff Only).')
+        .addStringOption(option =>
+            option.setName('id')
+                .setDescription('Event ID')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Cherry Blossom Breeze', value: 'blossom' },
+                    { name: 'Build Battle', value: 'build_battle' }
+                )
+        )
+        .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
+    async execute(interaction) {
+        const id = interaction.options.getString('id');
+        if (id === 'blossom') {
+            await startBlossom(interaction.client);
+            await interaction.reply({ content: 'Cherry Blossom Breeze started.', ephemeral: true });
+        } else if (id === 'build_battle') {
+            await initBuildBattleEvent(interaction.client);
+            await interaction.reply({ content: 'Build Battle event initialized.', ephemeral: true });
+        } else {
+            await interaction.reply({ content: 'Unknown event ID.', ephemeral: true });
+        }
+    },
+};

--- a/commands/start-weather.js
+++ b/commands/start-weather.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
+const { startRain } = require('../utils/weatherManager');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('start-weather')
+        .setDescription('Start a weather effect (Staff Only).')
+        .addStringOption(option =>
+            option.setName('id')
+                .setDescription('Weather ID')
+                .setRequired(true)
+                .addChoices(
+                    { name: 'Rain', value: 'rain' }
+                )
+        )
+        .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
+    async execute(interaction) {
+        const id = interaction.options.getString('id');
+        if (id === 'rain') {
+            await startRain(interaction.client);
+            await interaction.reply({ content: 'Rain has started.', ephemeral: true });
+        } else {
+            await interaction.reply({ content: 'Unknown weather ID.', ephemeral: true });
+        }
+    },
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -487,6 +487,39 @@ const commands = [
         ]
     },
     {
+        name: 'start-weather',
+        description: 'Start a weather effect (Staff Only).',
+        options: [
+            {
+                name: 'id',
+                description: 'Weather ID',
+                type: ApplicationCommandOptionType.String,
+                required: true,
+                choices: [
+                    { name: 'Rain', value: 'rain' }
+                ]
+            }
+        ],
+        default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
+    },
+    {
+        name: 'start-event',
+        description: 'Start a special event (Staff Only).',
+        options: [
+            {
+                name: 'id',
+                description: 'Event ID',
+                type: ApplicationCommandOptionType.String,
+                required: true,
+                choices: [
+                    { name: 'Cherry Blossom Breeze', value: 'blossom' },
+                    { name: 'Build Battle', value: 'build_battle' }
+                ]
+            }
+        ],
+        default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
+    },
+    {
         name: 'daily',
         description: 'Commands for daily rewards and streaks.',
         options: [

--- a/utils/weatherManager.js
+++ b/utils/weatherManager.js
@@ -95,4 +95,12 @@ async function initWeather(client) {
     setInterval(() => rollWeather(client).catch(() => {}), 60 * 60 * 1000);
 }
 
-module.exports = { initWeather, buildWeatherEmbed, getCatchMultiplier, isBlossomActive, getActiveWeatherList };
+module.exports = {
+    initWeather,
+    buildWeatherEmbed,
+    getCatchMultiplier,
+    isBlossomActive,
+    getActiveWeatherList,
+    startRain,
+    startBlossom
+};


### PR DESCRIPTION
## Summary
- add `start-weather` command for staff to manually trigger rain
- add `start-event` command for staff to begin cherry blossom breeze or build battle
- export helper functions from `weatherManager`
- register the new commands for deployment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68754b53520c832c963e57452852aa78