### PR TITLE
Fix start-event/weather reply handling and remove build battle

### DIFF
--- a/commands/start-event.js
+++ b/commands/start-event.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
 const { startBlossom } = require('../utils/weatherManager');
-const { initBuildBattleEvent } = require('../buildBattleEvent');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -11,21 +10,20 @@ module.exports = {
                 .setDescription('Event ID')
                 .setRequired(true)
                 .addChoices(
-                    { name: 'Cherry Blossom Breeze', value: 'blossom' },
-                    { name: 'Build Battle', value: 'build_battle' }
+                    { name: 'Cherry Blossom Breeze', value: 'blossom' }
                 )
         )
         .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
     async execute(interaction) {
         const id = interaction.options.getString('id');
+        let response;
         if (id === 'blossom') {
             await startBlossom(interaction.client);
-            await interaction.reply({ content: 'Cherry Blossom Breeze started.', ephemeral: true });
-        } else if (id === 'build_battle') {
-            await initBuildBattleEvent(interaction.client);
-            await interaction.reply({ content: 'Build Battle event initialized.', ephemeral: true });
+            response = { content: 'Cherry Blossom Breeze started.', ephemeral: true };
         } else {
-            await interaction.reply({ content: 'Unknown event ID.', ephemeral: true });
+            response = { content: 'Unknown event ID.', ephemeral: true };
         }
+        if (interaction.deferred || interaction.replied) return interaction.editReply(response);
+        return interaction.reply(response);
     },
 };

--- a/commands/start-weather.js
+++ b/commands/start-weather.js
@@ -16,11 +16,14 @@ module.exports = {
         .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
     async execute(interaction) {
         const id = interaction.options.getString('id');
+        let response;
         if (id === 'rain') {
             await startRain(interaction.client);
-            await interaction.reply({ content: 'Rain has started.', ephemeral: true });
+            response = { content: 'Rain has started.', ephemeral: true };
         } else {
-            await interaction.reply({ content: 'Unknown weather ID.', ephemeral: true });
+            response = { content: 'Unknown weather ID.', ephemeral: true };
         }
+        if (interaction.deferred || interaction.replied) return interaction.editReply(response);
+        return interaction.reply(response);
     },
 };

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -512,8 +512,7 @@ const commands = [
                 type: ApplicationCommandOptionType.String,
                 required: true,
                 choices: [
-                    { name: 'Cherry Blossom Breeze', value: 'blossom' },
-                    { name: 'Build Battle', value: 'build_battle' }
+                    { name: 'Cherry Blossom Breeze', value: 'blossom' }
                 ]
             }
         ],


### PR DESCRIPTION
## Summary
- use `editReply` when interactions are already deferred in `/start-event` and `/start-weather`
- remove build battle from `/start-event` choices and command logic
- update deploy definitions for `/start-event`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68754e59fda8832cb88645a15d3555e5