### PR TITLE
Add /check-weather command and emoji update

### DIFF
--- a/commands/check-weather.js
+++ b/commands/check-weather.js
@@ -1,10 +1,30 @@
+// commands/check-weather.js
 const { SlashCommandBuilder } = require('discord.js');
+const { buildWeatherEmbed, getActiveWeatherList, activeUntil } = require('../utils/weatherManager');
+
+function formatDuration(ms) {
+    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}m ${seconds}s`;
+}
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('check-weather')
         .setDescription('Check the current fishing weather.'),
     async execute(interaction) {
-        await interaction.reply({ content: 'Fetching weather...', ephemeral: false });
+        const embed = buildWeatherEmbed();
+        const active = getActiveWeatherList();
+        if (active.length) {
+            const durations = active.map(w => `- **${w}** ends in ${formatDuration(activeUntil[w] - Date.now())}`);
+            embed.addFields({ name: 'Time Remaining', value: durations.join('\n') });
+        }
+
+        if (interaction.replied || interaction.deferred) {
+            await interaction.editReply({ embeds: [embed] });
+        } else {
+            await interaction.reply({ embeds: [embed], ephemeral: false });
+        }
     },
 };

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -117,6 +117,10 @@ const commands = [
         description: 'Replies with Pong! and the bot\'s latency.',
     },
     {
+        name: 'check-weather',
+        description: 'Displays the current fishing weather.',
+    },
+    {
         name: 'botinfo',
         description: 'Displays information about Maxwell Bot'
     },

--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ const FISH_RARITY_COLORS = {
 const RARITY_SYMBOL_TO_NAME = { C: 'Common', U: 'Uncommon', R: 'Rare', E: 'Epic', L: 'Legendary', M: 'Mythical', S: 'Secret' };
 const RARITY_NAME_TO_SYMBOL = { Common: 'C', Uncommon: 'U', Rare: 'R', Epic: 'E', Legendary: 'L', Mythical: 'M', Secret: 'S' };
 const ORDERED_RARITIES = ['Common','Uncommon','Rare','Epic','Legendary','Mythical','Secret'];
-const MUTATION_BLOSSOM_EMOJI = '<:mutation-blossom:1394379938748043374>';
+const MUTATION_BLOSSOM_EMOJI = '<:mutationblossom:1394379938748043374>';
 const BASE_FISH_CHANCE = 0.6;
 
 const BANK_MAXED_ROLE_ID = '1380872298143416340';
@@ -3675,9 +3675,17 @@ module.exports = {
                  return;
             }
             if (commandName === 'check-weather') {
-                 if (!interaction.replied && !interaction.deferred) { await safeDeferReply(interaction, { ephemeral: false }); deferredThisInteraction = true; }
-                 const embed = buildWeatherEmbed();
-                 await safeEditReply(interaction, { embeds: [embed] }, true);
+                 if (!interaction.replied && !interaction.deferred) {
+                     await safeDeferReply(interaction, { ephemeral: false });
+                     deferredThisInteraction = true;
+                 }
+                 const cmd = client.commands.get('check-weather');
+                 if (cmd && typeof cmd.execute === 'function') {
+                     await cmd.execute(interaction, client);
+                 } else {
+                     const embed = buildWeatherEmbed();
+                     await safeEditReply(interaction, { embeds: [embed] }, true);
+                 }
                  return;
             }
             if (commandName === 'level') {


### PR DESCRIPTION
## Summary
- implement new `/check-weather` command that shows current weather and remaining durations
- register `/check-weather` in command deployment list
- update the mutation blossom emoji constant
- call the command from interaction handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875540d6b00832cba11bf165d7a3406