### PR TITLE
Change season reset time to UTC+7

### DIFF
--- a/utils/fishSeasonManager.js
+++ b/utils/fishSeasonManager.js
@@ -15,8 +15,10 @@ const SEASONS = [
 
 function startOfToday() {
   const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d.getTime();
+  // Convert to UTC+7 then snap to 00:00 in that zone
+  d.setUTCHours(d.getUTCHours() + 7, 0, 0, 0);
+  // Convert back to UTC timestamp
+  return d.getTime() - 7 * 60 * 60 * 1000;
 }
 
 async function loadData() {


### PR DESCRIPTION
## Summary
- adjust `startOfToday` so seasons reset at 00:00 UTC+7

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877c90305c4832cb4136f6f47baf6cd