### PR TITLE
Fix build battle countdown update

### DIFF
--- a/buildBattleEvent.js
+++ b/buildBattleEvent.js
@@ -144,6 +144,9 @@ async function updateCountdownMessage(channel, data) {
 
 function startCountdownInterval(channel, data) {
   clearInterval(countdownInterval);
+  // Immediately update the countdown message so changes to COUNTDOWN_END
+  // are reflected without waiting for the first interval tick
+  updateCountdownMessage(channel, data).catch(() => {});
   countdownInterval = setInterval(async () => {
     const now = Math.floor(Date.now() / 1000);
     if (now >= COUNTDOWN_END) {


### PR DESCRIPTION
## Summary
- immediately update the build battle countdown when starting the interval so changes are reflected right away

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687a12ca8b0c832dae2a665bd71a2209