### PR TITLE
Fix give-item remove option missing in deployment script

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -323,7 +323,13 @@ const commands = [
                 required: true,
                 autocomplete: true
             },
-            { name: 'amount', description: 'Amount of the item to give.', type: ApplicationCommandOptionType.Integer, required: true, minValue: 1 }
+            { name: 'amount', description: 'Amount of the item to give.', type: ApplicationCommandOptionType.Integer, required: true, minValue: 1 },
+            {
+                name: 'remove',
+                description: 'Remove the item instead of giving.',
+                type: ApplicationCommandOptionType.Boolean,
+                required: true
+            }
         ],
         default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
     },


### PR DESCRIPTION
## Summary
- add missing `remove` boolean option for `/give-item` in `deployCommands.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cd571ff20832da260b53d18362344