### PR TITLE
Add random elimination mini-game command

### DIFF
--- a/commands/random-eli.js
+++ b/commands/random-eli.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const { startRandomElimination } = require('../utils/randomElimination');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('random-eli')
+        .setDescription('Start a random elimination game.')
+        .addChannelOption(option =>
+            option.setName('channel')
+                .setDescription('Channel to host the game in')
+                .addChannelTypes(ChannelType.GuildText)
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName('prize')
+                .setDescription('Prize for the winner')
+                .setRequired(true)),
+    async execute(interaction) {
+        const targetChannel = interaction.options.getChannel('channel');
+        const prize = interaction.options.getString('prize');
+
+        await interaction.reply({ content: 'Starting random elimination...', ephemeral: true });
+
+        const members = await interaction.guild.members.fetch();
+        startRandomElimination(targetChannel, Array.from(members.values()), prize);
+    },
+};

--- a/utils/randomElimination.js
+++ b/utils/randomElimination.js
@@ -1,0 +1,57 @@
+const { EmbedBuilder } = require('discord.js');
+
+const BLACK = '⬛';
+const RED = '🟥';
+
+function sleep(ms) {
+    return new Promise(res => setTimeout(res, ms));
+}
+
+function buildDescription(players) {
+    return players
+        .map(p => `${p.member} ${RED.repeat(p.red)}${BLACK.repeat(5 - p.red)}`)
+        .join('\n');
+}
+
+async function startRandomElimination(channel, members, prize) {
+    const players = members
+        .filter(m => !m.user.bot)
+        .map(m => ({ member: m.toString(), id: m.id, red: 0 }));
+
+    if (players.length < 2) {
+        await channel.send({ content: 'Not enough players to start the game.' });
+        return;
+    }
+
+    let embed = new EmbedBuilder()
+        .setTitle('Random Elimination')
+        .setDescription(buildDescription(players))
+        .setFooter({ text: `Prize: ${prize}` })
+        .setColor('#ff0000');
+
+    const message = await channel.send({ embeds: [embed] });
+
+    while (players.filter(p => p.red < 5).length > 1) {
+        await sleep(3000);
+        const alive = players.filter(p => p.red < 5);
+        const random = alive[Math.floor(Math.random() * alive.length)];
+        random.red++;
+        embed.setDescription(buildDescription(players));
+        await message.edit({ embeds: [embed] });
+    }
+
+    const winner = players.find(p => p.red < 5);
+    if (winner) {
+        const winEmbed = new EmbedBuilder()
+            .setTitle('We have a winner!')
+            .setDescription(`${winner.member} wins ${prize}!`)
+            .setColor('#00ff00');
+        await channel.send({ embeds: [winEmbed] });
+    } else {
+        await channel.send({ content: 'No winner determined.' });
+    }
+}
+
+module.exports = {
+    startRandomElimination
+};


### PR DESCRIPTION
## Summary
- create `/random-eli` command to run a simple elimination game
- implement `randomElimination` utility for game logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d125caf98832d8e15aaf9bb9cd2cd