### PR TITLE
Add random-eli command to deploy

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -597,6 +597,25 @@ const commands = [
     {
         name: 'submit-ticket',
         description: 'Create a private build submission channel.'
+    },
+    {
+        name: 'random-eli',
+        description: 'Start a random elimination game.',
+        options: [
+            {
+                name: 'channel',
+                description: 'Channel to host the game in',
+                type: ApplicationCommandOptionType.Channel,
+                channel_types: [ChannelType.GuildText],
+                required: true,
+            },
+            {
+                name: 'prize',
+                description: 'Prize for the winner',
+                type: ApplicationCommandOptionType.String,
+                required: true,
+            }
+        ]
     }
 ];
 


### PR DESCRIPTION
## Summary
- include the new `/random-eli` slash command in `deployCommands.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d14f5b830832d9201eb5e50d7eb65