### PR TITLE
Fix random elimination command reply

### DIFF
--- a/commands/random-eli.js
+++ b/commands/random-eli.js
@@ -18,7 +18,12 @@ module.exports = {
         const targetChannel = interaction.options.getChannel('channel');
         const prize = interaction.options.getString('prize');
 
-        await interaction.reply({ content: 'Starting random elimination...', ephemeral: true });
+        const replyOptions = { content: 'Starting random elimination...', ephemeral: true };
+        if (interaction.deferred || interaction.replied) {
+            await interaction.editReply(replyOptions);
+        } else {
+            await interaction.reply(replyOptions);
+        }
 
         const members = await interaction.guild.members.fetch();
         startRandomElimination(targetChannel, Array.from(members.values()), prize);


### PR DESCRIPTION
## Summary
- handle case where interaction was already deferred by handler

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687d1769c818832d8ad228f21a638b0c