### PR TITLE
Fix Split-Steal DM interaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -2989,8 +2989,9 @@ client.on('interactionCreate', async interaction => {
     // FIX 2: Allow specific DM interactions like giveaway claims
     const isGiveawayClaimInteraction = interaction.isButton() && interaction.customId?.startsWith('claim_');
     const isDailyStreakRestore = interaction.isButton() && interaction.customId?.startsWith('restore_streak_confirm');
+    const isSplitStealInteraction = interaction.isButton() && interaction.customId?.startsWith('splitsteal_');
 
-    if (!interaction.guild && !isGiveawayClaimInteraction && !isDailyStreakRestore) {
+    if (!interaction.guild && !isGiveawayClaimInteraction && !isDailyStreakRestore && !isSplitStealInteraction) {
         if (interaction.isRepliable() && !interaction.replied && !interaction.deferred) {
             await interaction.reply({ content: "Sorry, I can only work inside servers.", ephemeral: true }).catch(() => {});
         }


### PR DESCRIPTION
## Summary
- allow `split-steal` buttons to work from DMs by whitelisting their custom IDs in the interaction gate

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_687d236e6234832d86a32e597722e644