### PR TITLE
Schedule leaderboard daily at UTC+7 midnight and update AFK reply

### DIFF
--- a/utils/afkMessages.js
+++ b/utils/afkMessages.js
@@ -21,7 +21,7 @@ module.exports = [
 `@silent 🚷 Access denied. {user} locked the door and left.`,
 `@silent 🤬 One more ping and I revoke your typing licence, {author}.`,
 `@silent 😒 Congratulations, you just spoke to thin air.`,
-`@silent 🗯️ “Hello?”—No response—SURPRISE, AFK!`,
+`🗯️ “Hello?”—No response—SURPRISE, AFK!`,
 `@silent 🔥 Your desperation is showing, {author}. Calm down.`,
 `@silent 🙅 Nope. Not happening. {user} is AFK.`,
 `@silent 💢 Repeat after me: A… F… K!`,


### PR DESCRIPTION
## Summary
- run leaderboard update once per day exactly at UTC+7 midnight
- stop mentioning users when replying to pings on AFK users
- update one AFK message to remove the `@silent` prefix

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fb1a7927c832d8f273412caef2fef