### PR TITLE
Schedule leaderboard daily at UTC+7 midnight

### DIFF
--- a/index.js
+++ b/index.js
@@ -1323,12 +1323,14 @@ async function scheduleDailyLeaderboardUpdate(client) {
         }
     };
     const scheduleNextRun = () => {
-        const offsetMs = 7 * 60 * 60 * 1000; // UTC+7
         const now = new Date();
-        const nowUtc7 = new Date(now.getTime() + offsetMs);
-        const nextMidnightUtc7 = new Date(nowUtc7);
-        nextMidnightUtc7.setUTCHours(24, 0, 0, 0);
-        const delay = nextMidnightUtc7 - nowUtc7;
+        const nextUpdate = new Date(now);
+        // 24:00 in UTC+7 corresponds to 17:00 UTC
+        nextUpdate.setUTCHours(17, 0, 0, 0);
+        if (nextUpdate <= now) {
+            nextUpdate.setUTCDate(nextUpdate.getUTCDate() + 1);
+        }
+        const delay = nextUpdate - now;
         setTimeout(async () => {
             await updateLeaderboard();
             scheduleNextRun();

--- a/leaderboardManager.js
+++ b/leaderboardManager.js
@@ -277,7 +277,7 @@ async function postOrUpdateLeaderboard(client, guildId, systemsManager, limit, i
         const lastUpdated = settings.leaderboardLastUpdated;
         const now = Date.now();
 
-        const updateInterval = 60 * 60 * 1000; // 1 hour
+        const updateInterval = 24 * 60 * 60 * 1000; // 24 hours
 
         // If not forced by admin, check the update interval
         if (!isForcedByAdmin && lastUpdated && (now - lastUpdated < updateInterval)) {


### PR DESCRIPTION
## Summary
- update the leaderboard scheduler to calculate the next run at 24:00 UTC+7
- adjust leaderboard manager interval to 24h so countdown reflects daily updates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688117041d7c832dbfcc8e08730af293