### PR TITLE
Add DM slash command

### DIFF
--- a/commands/dm.js
+++ b/commands/dm.js
@@ -1,0 +1,17 @@
+// commands/dm.js
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('dm')
+        .setDescription('Send an anonymous DM to a user.')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('The user to DM')
+                .setRequired(true)
+        ),
+    async execute(interaction) {
+        // Actual logic handled in index.js when showing the modal and sending the message
+        await interaction.reply({ content: 'Opening DM form...', ephemeral: true });
+    },
+};

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -137,6 +137,18 @@ const commands = [
         description: 'Displays information about Maxwell Bot'
     },
     {
+        name: 'dm',
+        description: 'Send an anonymous DM to a user.',
+        options: [
+            {
+                name: 'user',
+                description: 'The user to DM',
+                type: ApplicationCommandOptionType.User,
+                required: true,
+            }
+        ]
+    },
+    {
         name: 'createembed',
         description: 'Start building an embed message to send (Staff Only).',
         options: [

--- a/index.js
+++ b/index.js
@@ -4746,6 +4746,30 @@ module.exports = {
                 return;
             }
 
+            if (customId.startsWith('dm_modal_')) {
+                if (!interaction.isModalSubmit()) return;
+
+                if (!interaction.replied && !interaction.deferred) {
+                    await safeDeferReply(interaction, { ephemeral: true });
+                    deferredThisInteraction = true;
+                }
+
+                const targetId = customId.split('_')[2];
+                const messageText = interaction.fields.getTextInputValue('dm_content');
+                const targetUser = await client.users.fetch(targetId).catch(() => null);
+                if (!targetUser) {
+                    return sendInteractionError(interaction, 'Could not find that user.', true, deferredThisInteraction);
+                }
+                try {
+                    await targetUser.send({ content: messageText });
+                    await safeEditReply(interaction, { content: '✅ Message sent.', ephemeral: true });
+                } catch (err) {
+                    console.error('[DM Command] Failed to send DM:', err);
+                    await sendInteractionError(interaction, 'Failed to send DM. They might have DMs disabled.', true, deferredThisInteraction);
+                }
+                return;
+            }
+
 
             if (customId.startsWith('rwr_accept_') || customId.startsWith('rwr_deny_')) {
                 if (!interaction.isButton()) return;


### PR DESCRIPTION
## Summary
- add new `/dm` command for anonymous messaging
- support DM modal and send logic in `index.js`
- include `/dm` in deploy command list

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68811ae6a2a0832db3b3ef39c7cd32c9