### PR TITLE
Fix leftover loot box IDs

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,10 @@ const ITEM_IDS = {
     COINS: gameConfig.items.coins?.id || 'coins',
     GEMS: gameConfig.items.gems?.id || 'gems',
     ROBUX: gameConfig.items.robux?.id || 'robux',
-    COMMON_LOOT_BOX: gameConfig.items.common_chest?.id || 'common_chest',
-    RARE_LOOT_BOX: gameConfig.items.rare_chest?.id || 'rare_chest',
-    EPIC_LOOT_BOX: gameConfig.items.epic_chest?.id || 'epic_chest',
-    LEGENDARY_LOOT_BOX: gameConfig.items.legendary_chest?.id || 'legendary_chest',
+    COMMON_CHEST: gameConfig.items.common_chest?.id || 'common_chest',
+    RARE_CHEST: gameConfig.items.rare_chest?.id || 'rare_chest',
+    EPIC_CHEST: gameConfig.items.epic_chest?.id || 'epic_chest',
+    LEGENDARY_CHEST: gameConfig.items.legendary_chest?.id || 'legendary_chest',
     MYTHICAL_CHEST: gameConfig.items.mythical_chest?.id || 'mythical_chest',
     MAGIC_CHEST: gameConfig.items.magic_chest?.id || 'magic_chest',
     GEM_CHEST: gameConfig.items.gem_chest?.id || 'gem_chest',
@@ -196,10 +196,10 @@ const ROBUX_WITHDRAWAL_LOG_CHANNEL_ID = '1379495267031846952'; // YOUR_CHANNEL_I
 const BOT_LOG_CHANNEL_ID = process.env.BOT_LOG_CHANNEL_ID || '1383481711651721307';
 
 const MAX_UNBOX_AMOUNTS = gameConfig.globalSettings?.MAX_UNBOX_AMOUNTS || {
-    [ITEM_IDS.COMMON_LOOT_BOX]: 300,
-    [ITEM_IDS.RARE_LOOT_BOX]: 200,
-    [ITEM_IDS.EPIC_LOOT_BOX]: 100,
-    [ITEM_IDS.LEGENDARY_LOOT_BOX]: 50,
+    [ITEM_IDS.COMMON_CHEST]: 300,
+    [ITEM_IDS.RARE_CHEST]: 200,
+    [ITEM_IDS.EPIC_CHEST]: 100,
+    [ITEM_IDS.LEGENDARY_CHEST]: 50,
 };
 
 const LEVEL_SPECIFIC_IMAGE_URLS = {

--- a/systems.js
+++ b/systems.js
@@ -117,10 +117,10 @@ class SystemsManager {
         this.GEMS_ID = this.gameConfig.items.gems?.id || 'gems';
         this.ROBUX_ID = this.gameConfig.items.robux?.id || 'robux';
         this.FISH_DOLLAR_ID = this.gameConfig.items.fish_dollar?.id || 'fish_dollar';
-        this.COMMON_LOOT_BOX_ID = this.gameConfig.items.common_chest?.id || 'common_chest';
-        this.RARE_LOOT_BOX_ID = this.gameConfig.items.rare_chest?.id || 'rare_chest';
-        this.EPIC_LOOT_BOX_ID = this.gameConfig.items.epic_chest?.id || 'epic_chest';
-        this.LEGENDARY_LOOT_BOX_ID = this.gameConfig.items.legendary_chest?.id || 'legendary_chest';
+        this.COMMON_CHEST_ID = this.gameConfig.items.common_chest?.id || 'common_chest';
+        this.RARE_CHEST_ID = this.gameConfig.items.rare_chest?.id || 'rare_chest';
+        this.EPIC_CHEST_ID = this.gameConfig.items.epic_chest?.id || 'epic_chest';
+        this.LEGENDARY_CHEST_ID = this.gameConfig.items.legendary_chest?.id || 'legendary_chest';
         this.COIN_CHARM_ID = this.gameConfig.items.coin_charm?.id || 'coin_charm';
         this.GEM_CHARM_ID = this.gameConfig.items.gem_charm?.id || 'gem_charm';
         this.XP_CHARM_ID = this.gameConfig.items.xp_charm?.id || 'xp_charm';
@@ -2068,10 +2068,10 @@ this.db.prepare(`
             // --- Item Reward ---
             const baseItemPool = [
                 // Probabilities normalise to the item chance of 50% when no luck is applied.
-                { id: this.COMMON_LOOT_BOX_ID, baseProb: 0.80 },
-                { id: this.RARE_LOOT_BOX_ID, baseProb: 0.195 },
-                { id: this.EPIC_LOOT_BOX_ID, baseProb: 0.0049 },
-                { id: this.LEGENDARY_LOOT_BOX_ID, baseProb: 0.0001 },
+                { id: this.COMMON_CHEST_ID, baseProb: 0.80 },
+                { id: this.RARE_CHEST_ID, baseProb: 0.195 },
+                { id: this.EPIC_CHEST_ID, baseProb: 0.0049 },
+                { id: this.LEGENDARY_CHEST_ID, baseProb: 0.0001 },
                 { id: this.COIN_CHARM_ID, baseProb: 0.000005 },
                 { id: this.GEM_CHARM_ID, baseProb: 0.0000001 },
                 { id: this.XP_CHARM_ID, baseProb: 0.0000008 },
@@ -2087,7 +2087,7 @@ this.db.prepare(`
 
             let totalRareProb = 0;
             const dynamicPool = baseItemPool.map(item => {
-                const isRare = item.id !== this.COMMON_LOOT_BOX_ID && !item.noLuck;
+                const isRare = item.id !== this.COMMON_CHEST_ID && !item.noLuck;
                 const baseProbability = item.baseProb / totalBaseProb;
                 // Slightly stronger luck scaling so max boost is more impactful
                 // Increased multiplier so luck gives a bit more item chance
@@ -2098,7 +2098,7 @@ this.db.prepare(`
                 return { ...item, finalProb };
             });
 
-            const commonItem = dynamicPool.find(item => item.id === this.COMMON_LOOT_BOX_ID);
+            const commonItem = dynamicPool.find(item => item.id === this.COMMON_CHEST_ID);
             if (commonItem) {
                 commonItem.finalProb = Math.max(0, 1 - totalRareProb);
             }


### PR DESCRIPTION
## Summary
- rename loot box constants to chest constants
- update references to new chest constant names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881bbc9dafc832da021086406bf98e1