### PR TITLE
Fix leaderboard countdown to midnight

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ const {
     ROBUX_WITHDRAWAL_COOLDOWN_MS // New constant from systems.js
 } = require('./systems.js');
 
-const { postOrUpdateLeaderboard, updateLeaderboardRewards, formatLeaderboardEmbed, formatCoinLeaderboardEmbed, formatGemLeaderboardEmbed, formatValueLeaderboardEmbed } = require('./leaderboardManager.js');
+const { postOrUpdateLeaderboard, updateLeaderboardRewards, formatLeaderboardEmbed, formatCoinLeaderboardEmbed, formatGemLeaderboardEmbed, formatValueLeaderboardEmbed, getMsUntilNextDailyUpdate } = require('./leaderboardManager.js');
 const DEFAULT_COIN_EMOJI_FALLBACK = '<:JAGcoin:1397581543354142881>';
 const DEFAULT_GEM_EMOJI_FALLBACK = '<a:gem:1374405019918401597>';
 const DEFAULT_ROBUX_EMOJI_FALLBACK = '<a:robux:1378395622683574353>'; // New
@@ -4181,16 +4181,17 @@ module.exports = {
                     const gemData = client.levelSystem.getGemLeaderboard(guildId, 5);
                     const valueData = client.levelSystem.getValueLeaderboard(guildId, 5);
 
+                    const timeUntilNext = getMsUntilNextDailyUpdate();
                     const embed = await formatLeaderboardEmbed(
                         leaderboardData,
                         client,
                         guildId,
                         client.levelSystem,
-                        60 * 60 * 1000
+                        timeUntilNext
                     );
-                    const coinEmbed = await formatCoinLeaderboardEmbed(coinData, client, 60 * 60 * 1000);
-                    const gemEmbed = await formatGemLeaderboardEmbed(gemData, client, 60 * 60 * 1000);
-                    const valueEmbed = await formatValueLeaderboardEmbed(valueData, client, 60 * 60 * 1000);
+                    const coinEmbed = await formatCoinLeaderboardEmbed(coinData, client, timeUntilNext);
+                    const gemEmbed = await formatGemLeaderboardEmbed(gemData, client, timeUntilNext);
+                    const valueEmbed = await formatValueLeaderboardEmbed(valueData, client, timeUntilNext);
 
                     await safeEditReply(interaction, { embeds: [embed, coinEmbed, gemEmbed, valueEmbed], ephemeral: false }, true);
                 } else if (subcommand === 'postnow') {


### PR DESCRIPTION
## Summary
- compute ms until next daily leaderboard update
- show this countdown in leaderboard embeds
- use the new countdown in `/leaderboard view`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881cf02a3c4832d946be920f66ef968