### PR TITLE
Add user option to reroll-theme command

### DIFF
--- a/buildBattleEvent.js
+++ b/buildBattleEvent.js
@@ -273,23 +273,24 @@ async function handleJoinInteraction(interaction) {
   }
 }
 
-async function rerollUserTheme(interaction) {
+async function rerollUserTheme(interaction, targetUser = interaction.user) {
   const data = await loadData();
-  if (!data.userThemes || !data.userThemes[interaction.user.id]) {
-    return interaction.reply({ content: 'You have not joined the build battle.', ephemeral: true });
+  if (!data.userThemes || !data.userThemes[targetUser.id]) {
+    const msg = targetUser.id === interaction.user.id ? 'You have' : 'That user has';
+    return interaction.reply({ content: `${msg} not joined the build battle.`, ephemeral: true });
   }
   const theme = THEMES[Math.floor(Math.random() * THEMES.length)];
-  data.userThemes[interaction.user.id] = theme;
+  data.userThemes[targetUser.id] = theme;
   await saveData(data);
-  await interaction.reply({ content: 'Check your DMs for your new theme!', ephemeral: true });
+  await interaction.reply({ content: `Check your DMs for the new theme!`, ephemeral: true });
   const embed = new EmbedBuilder()
     .setTitle('PSST')
-    .setDescription(`${interaction.user}, you have got a theme!\n# ${theme}\n* You should start your building now! The submit ticket will be closed on <t:${THEME_CLOSE_TS}:F>!\n* Besure to screenshot some of your building progress!! Trust me you gonna need it!. Also if you have done building, please create a submit ticket by using command </submit-ticket:1392510566945525781>\n* Also read the rules in https://discord.com/channels/1372572233930903592/1390743854487044136 before submitting!`)
+    .setDescription(`${targetUser}, you have got a theme!\n# ${theme}\n* You should start your building now! The submit ticket will be closed on <t:${THEME_CLOSE_TS}:F>!\n* Besure to screenshot some of your building progress!! Trust me you gonna need it!. Also if you have done building, please create a submit ticket by using command </submit-ticket:1392510566945525781>\n* Also read the rules in https://discord.com/channels/1372572233930903592/1390743854487044136 before submitting!`)
     .setFooter({ text: 'have fun!' });
-  await interaction.user.send({ embeds: [embed] }).catch(() => {});
+  await targetUser.send({ embeds: [embed] }).catch(() => {});
   const logChannel = await interaction.client.channels.fetch(LOG_CHANNEL_ID).catch(() => null);
   if (logChannel && logChannel.isTextBased()) {
-    await logChannel.send({ content: `Username: ${interaction.user}\nTheme rerolled: ${theme}` }).catch(() => {});
+    await logChannel.send({ content: `Username: ${targetUser}\nTheme rerolled: ${theme}` }).catch(() => {});
   }
 }
 

--- a/commands/reroll-theme.js
+++ b/commands/reroll-theme.js
@@ -3,8 +3,13 @@ const { SlashCommandBuilder } = require('discord.js');
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('reroll-theme')
-        .setDescription('Reroll your build battle theme.'),
+        .setDescription('Reroll a build battle theme for yourself or another user.')
+        .addUserOption(option =>
+            option.setName('user')
+                .setDescription('User to reroll the theme for')
+                .setRequired(false)
+        ),
     async execute(interaction) {
-        await interaction.reply({ content: 'Rerolling your theme...', ephemeral: true });
+        await interaction.reply({ content: 'Rerolling theme...', ephemeral: true });
     },
 };

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -623,6 +623,18 @@ const commands = [
         description: 'Create a private build submission channel.'
     },
     {
+        name: 'reroll-theme',
+        description: 'Reroll a build battle theme for a user.',
+        options: [
+            {
+                name: 'user',
+                description: 'User to reroll the theme for',
+                type: ApplicationCommandOptionType.User,
+                required: false,
+            }
+        ]
+    },
+    {
         name: 'split-steal',
         description: 'Start a Split or Steal game between two users.',
         options: [

--- a/index.js
+++ b/index.js
@@ -3885,7 +3885,8 @@ module.exports = {
                      await safeDeferReply(interaction, { ephemeral: true });
                      deferredThisInteraction = true;
                  }
-                 await rerollUserTheme(interaction).catch(e => {
+                 const targetUser = interaction.options.getUser('user') || interaction.user;
+                 await rerollUserTheme(interaction, targetUser).catch(e => {
                      console.error('[reroll-theme]', e);
                      sendInteractionError(interaction, 'Failed to reroll theme.', true, deferredThisInteraction);
                  });


### PR DESCRIPTION
## Summary
- support `/reroll-theme` for other users
- deploy the command with a `user` option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68826bf68ab0832d800e83eb2e3df3a9