### PR TITLE
Fix XP count

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -22,7 +22,7 @@ const config = {
         NON_DAILY_NOTIFICATIONS_ENABLED: true,
 
         BASE_COINS_PER_MESSAGE: [1, 10],
-        BASE_XP_PER_MESSAGE: 15,
+        BASE_XP_PER_MESSAGE: 1,
         XP_COOLDOWN_SECONDS: 60,
         VOICE_XP_PER_INTERVAL: 5,
         VOICE_COIN_PER_INTERVAL: [1, 2],

--- a/index.js
+++ b/index.js
@@ -2457,7 +2457,7 @@ async function buildInventoryEmbed(user, guildId, systemsManager, currentTab = '
             if (wk.currency && wk.currency > 1) coinBoost += (wk.currency - 1) * 100;
             if (wk.gem && wk.gem > 1) gemBoost += (wk.gem - 1) * 100;
             if (wk.xp && wk.xp > 1) {
-                const baseXp = systemsManager.gameConfig.globalSettings.BASE_XP_PER_MESSAGE[0] || XP_PER_MESSAGE_BASE;
+                const baseXp = systemsManager.gameConfig.globalSettings.BASE_XP_PER_MESSAGE || XP_PER_MESSAGE_BASE;
                 xpBoost += (baseXp + xpBoost) * (wk.xp - 1);
             }
 
@@ -2857,9 +2857,9 @@ client.on('messageCreate', async message => {
         let xpResult;
         try {
             // Use configured XP per message, fallback to global const
-            const configuredXpPerMessage = client.levelSystem.gameConfig.globalSettings.BASE_XP_PER_MESSAGE[0] || XP_PER_MESSAGE_BASE;
-            const xpWithPerks = configuredXpPerMessage + (rolePerkData.totals.xpPerMessage || 0);
-            xpResult = await client.levelSystem.addXP(message.author.id, message.guild.id, xpWithPerks, member, false, WEEKEND_MULTIPLIERS.xp); // Pass current weekend XP multiplier
+            const configuredXpPerMessage = client.levelSystem.gameConfig.globalSettings.BASE_XP_PER_MESSAGE || XP_PER_MESSAGE_BASE;
+            // Role perks are handled in addXP to avoid double counting
+            xpResult = await client.levelSystem.addXP(message.author.id, message.guild.id, configuredXpPerMessage, member, false, WEEKEND_MULTIPLIERS.xp); // Pass current weekend XP multiplier
             if (xpResult.leveledUp) {
                 const gemReward = Math.pow(xpResult.newLevel, 2);
                 client.levelSystem.addGems(message.author.id, message.guild.id, gemReward, "level_up");


### PR DESCRIPTION
## Summary
- set base XP per message to 1
- avoid role XP being added twice
- fix weekend XP boost calculation to use the base value

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688736de8c70832da6f2d90ec33a2a3d