### PR TITLE
Fix missing voice deps and reply handling

### DIFF
--- a/commands/nowplaying.js
+++ b/commands/nowplaying.js
@@ -8,9 +8,10 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         const current = queue.current();
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
         if (!current) {
-            return interaction.reply({ content: 'Nothing is playing.', ephemeral: true });
+            return interaction[method]({ content: 'Nothing is playing.', ephemeral: true });
         }
-        await interaction.reply({ content: `Now playing: ${current.url}` });
+        await interaction[method]({ content: `Now playing: ${current.url}` });
     }
 };

--- a/commands/pause.js
+++ b/commands/pause.js
@@ -8,6 +8,7 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         queue.pause();
-        await interaction.reply({ content: 'Paused playback.' });
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+        await interaction[method]({ content: 'Paused playback.' });
     }
 };

--- a/commands/play.js
+++ b/commands/play.js
@@ -14,12 +14,14 @@ module.exports = {
         const member = interaction.member;
         const voiceChannel = member.voice.channel;
         if (!voiceChannel) {
-            return interaction.reply({ content: 'You need to join a voice channel first!', ephemeral: true });
+            const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+            return interaction[method]({ content: 'You need to join a voice channel first!', ephemeral: true });
         }
         const queue = getQueue(interaction.guild.id);
         await queue.connect(voiceChannel);
         await queue.add(url, interaction.user);
         const position = queue.list().length;
-        await interaction.reply({ content: `Added to queue at position ${position}: ${url}` });
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+        await interaction[method]({ content: `Added to queue at position ${position}: ${url}` });
     },
 };

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -8,12 +8,13 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         const list = queue.list();
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
         if (!list.length) {
-            return interaction.reply({ content: 'The queue is empty.', ephemeral: true });
+            return interaction[method]({ content: 'The queue is empty.', ephemeral: true });
         }
         const embed = new EmbedBuilder()
             .setTitle('Music Queue')
             .setDescription(list.map((item, idx) => `${idx + 1}. ${item.url}`).join('\n'));
-        await interaction.reply({ embeds: [embed] });
+        await interaction[method]({ embeds: [embed] });
     }
 };

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -8,6 +8,7 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         queue.resume();
-        await interaction.reply({ content: 'Resumed playback.' });
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+        await interaction[method]({ content: 'Resumed playback.' });
     }
 };

--- a/commands/shuffle.js
+++ b/commands/shuffle.js
@@ -8,10 +8,11 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         const list = queue.list();
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
         if (list.length <= 1) {
-            return interaction.reply({ content: 'Not enough songs in queue to shuffle.', ephemeral: true });
+            return interaction[method]({ content: 'Not enough songs in queue to shuffle.', ephemeral: true });
         }
         queue.shuffle();
-        await interaction.reply({ content: 'Queue shuffled.' });
+        await interaction[method]({ content: 'Queue shuffled.' });
     }
 };

--- a/commands/skip.js
+++ b/commands/skip.js
@@ -8,6 +8,7 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         queue.skip();
-        await interaction.reply({ content: 'Skipped current song.' });
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+        await interaction[method]({ content: 'Skipped current song.' });
     }
 };

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -8,6 +8,7 @@ module.exports = {
     async execute(interaction) {
         const queue = getQueue(interaction.guild.id);
         queue.stop();
-        await interaction.reply({ content: 'Stopped playback and cleared queue.' });
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
+        await interaction[method]({ content: 'Stopped playback and cleared queue.' });
     }
 };

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -11,11 +11,12 @@ module.exports = {
                 .setRequired(true)),
     async execute(interaction) {
         const level = interaction.options.getInteger('level');
+        const method = interaction.deferred || interaction.replied ? 'editReply' : 'reply';
         if (level < 0 || level > 100) {
-            return interaction.reply({ content: 'Volume must be between 0 and 100.', ephemeral: true });
+            return interaction[method]({ content: 'Volume must be between 0 and 100.', ephemeral: true });
         }
         const queue = getQueue(interaction.guild.id);
         queue.setVolume(level / 100);
-        await interaction.reply({ content: `Volume set to ${level}%` });
+        await interaction[method]({ content: `Volume set to ${level}%` });
     }
 };

--- a/utils/opusInstaller.js
+++ b/utils/opusInstaller.js
@@ -1,0 +1,33 @@
+const { execSync } = require('child_process');
+
+function ensureOpus() {
+    let opusLoaded = false;
+    try {
+        require.resolve('@discordjs/opus');
+        opusLoaded = true;
+    } catch {}
+    if (!opusLoaded) {
+        try {
+            require.resolve('node-opus');
+            opusLoaded = true;
+        } catch {}
+    }
+    if (!opusLoaded) {
+        try {
+            require.resolve('opusscript');
+            opusLoaded = true;
+        } catch {}
+    }
+    if (!opusLoaded) {
+        try {
+            console.log('No Opus library found. Installing opusscript...');
+            execSync('npm install opusscript', { stdio: 'inherit' });
+            opusLoaded = true;
+            console.log('opusscript installed successfully.');
+        } catch (err) {
+            console.error('Failed to install opusscript automatically:', err.message);
+        }
+    }
+}
+
+module.exports = { ensureOpus };


### PR DESCRIPTION
## Summary
- add `opusInstaller` to automatically install an Opus library if none present
- load `opusInstaller` in `musicSystem`
- handle stream errors and 410 status when playing audio
- use safe reply logic in music commands so deferred interactions don't error

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688788bf41a0832d94c5be921564aa8d