### PR TITLE
Add play-dl cookie support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ npm install play-dl@latest
 ```
 
 Avoid caching YouTube links; always fetch a fresh stream.
+
+## Handling YouTube verification
+
+If `play-dl` fails with a message like `Sign in to confirm you're not a bot`,
+YouTube requires a valid account cookie.  Set the cookie string in the `YT_COOKIE`
+environment variable before starting the bot:
+
+```bash
+export YT_COOKIE="PREF=...; SID=...;"
+```
+
+The `musicSystem` module automatically applies this cookie when available.

--- a/musicSystem.js
+++ b/musicSystem.js
@@ -6,6 +6,8 @@ ensureLatestYtdlCore();
 const { joinVoiceChannel, createAudioPlayer, NoSubscriberBehavior, createAudioResource, StreamType, AudioPlayerStatus, getVoiceConnection } = require('@discordjs/voice');
 const ytdl = require('ytdl-core');
 const play = require('play-dl');
+const { applyPlayDlCookie } = require('./utils/playDlToken');
+applyPlayDlCookie();
 
 class MusicQueue {
     constructor() {

--- a/utils/playDlToken.js
+++ b/utils/playDlToken.js
@@ -1,0 +1,15 @@
+const play = require('play-dl');
+
+function applyPlayDlCookie() {
+    const cookie = process.env.YT_COOKIE;
+    if (cookie) {
+        try {
+            play.setToken({ yt: { cookie } });
+            console.log('play-dl cookie applied');
+        } catch (err) {
+            console.error('Failed to apply play-dl cookie:', err);
+        }
+    }
+}
+
+module.exports = { applyPlayDlCookie };


### PR DESCRIPTION
## Summary
- introduce a helper util to set a play-dl cookie
- apply the cookie in the music system
- document the new `YT_COOKIE` environment variable in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887a5cd457c832daca83a14ebb6c969