### PR TITLE
Fix double defer on play command

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -12,7 +12,7 @@ module.exports = {
                 .setRequired(true)),
     async execute(interaction) {
         const url = interaction.options.getString('url');
-        await interaction.deferReply();
+        // The parent handler already deferred the interaction if needed.
 
         if (!playdl.yt_validate(url)) {
             return interaction.editReply('❌ Please provide a valid YouTube URL.');


### PR DESCRIPTION
## Summary
- remove `deferReply` from play command because the parent handler already handles it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1744190832d846acda81282bed6