### PR TITLE
Enable play-dl cookie auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Maxwell Bot
 
 This project is a Discord bot for managing various server functions.
+
+## YouTube Audio Streaming
+
+The `/play` command streams audio from YouTube using the `play-dl` library.
+Some videos may require authentication. Set the `YT_COOKIE` environment
+variable with your YouTube cookie string if you encounter "Sign in to confirm
+you're not a bot" errors.
+
+Example `.env` entry:
+
+```env
+YT_COOKIE="SAPISID=...; HSID=...; SID=...; SSID=...;"
+```
+
+Never commit your cookie to version control.

--- a/commands/play.js
+++ b/commands/play.js
@@ -2,6 +2,15 @@ const { SlashCommandBuilder } = require('discord.js');
 const { joinVoiceChannel, createAudioPlayer, createAudioResource, AudioPlayerStatus } = require('@discordjs/voice');
 const playdl = require('play-dl');
 
+// Allow authenticated YouTube access if a cookie is provided via env variable
+if (process.env.YT_COOKIE) {
+    playdl.setToken({
+        youtube: {
+            cookie: process.env.YT_COOKIE,
+        },
+    });
+}
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('play')


### PR DESCRIPTION
## Summary
- allow providing a YouTube cookie via the `YT_COOKIE` env var when streaming
- document how to set `YT_COOKIE` in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6887b47f6330832d87cc230b99cfde44