### PR TITLE
Implement music playback commands

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -1,0 +1,154 @@
+const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+const { joinVoiceChannel, createAudioPlayer, createAudioResource, getVoiceConnection, AudioPlayerStatus } = require('@discordjs/voice');
+const ytdlp = require('yt-dlp-exec');
+const serverQueue = require('../queueManager');
+
+function createControlPanel(song, queue, playerState) {
+    const isPaused = playerState.status === AudioPlayerStatus.Paused;
+    const embed = new EmbedBuilder()
+        .setColor('#0099ff')
+        .setTitle('🎶 Now Playing')
+        .setDescription(`**[${song.title}](${song.url})**`)
+        .setThumbnail(song.thumbnail)
+        .addFields(
+            { name: 'Duration', value: `\`${song.duration}\``, inline: true },
+            { name: 'Requested by', value: `${song.requester}`, inline: true },
+            { name: 'Up Next', value: queue.songs[1] ? `\`${queue.songs[1].title}\`` : '`Nothing`', inline: true }
+        )
+        .setTimestamp();
+
+    const row = new ActionRowBuilder()
+        .addComponents(
+            new ButtonBuilder()
+                .setCustomId('music_pause_resume')
+                .setLabel(isPaused ? 'Resume' : 'Pause')
+                .setStyle(isPaused ? ButtonStyle.Success : ButtonStyle.Secondary)
+                .setEmoji(isPaused ? '▶️' : '⏸️'),
+            new ButtonBuilder()
+                .setCustomId('music_skip')
+                .setLabel('Skip')
+                .setStyle(ButtonStyle.Primary)
+                .setEmoji('⏭️'),
+            new ButtonBuilder()
+                .setCustomId('music_stop')
+                .setLabel('Stop')
+                .setStyle(ButtonStyle.Danger)
+                .setEmoji('⏹️')
+        );
+    return { embed, row };
+}
+
+async function play(guild, song) {
+    const queue = serverQueue.get(guild.id);
+    if (!song) {
+        if (queue.connection) queue.connection.destroy();
+        serverQueue.delete(guild.id);
+        return;
+    }
+
+    const stream = ytdlp.exec(song.url, { output: '-', format: 'bestaudio/best', preferFreeFormats: true }, { stdio: ['ignore', 'pipe', 'ignore'] });
+    const resource = createAudioResource(stream.stdout);
+    queue.player.play(resource);
+    queue.connection.subscribe(queue.player);
+
+    const { embed, row } = createControlPanel(song, queue, queue.player.state);
+    if (queue.nowPlayingMessage) {
+        await queue.nowPlayingMessage.edit({ embeds: [embed], components: [row] });
+    }
+
+    queue.player.off(AudioPlayerStatus.Idle);
+    queue.player.on(AudioPlayerStatus.Idle, () => {
+        queue.songs.shift();
+        play(guild, queue.songs[0]);
+    });
+}
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('play')
+        .setDescription('Plays a song from YouTube.')
+        .addStringOption(option => option.setName('song').setDescription('The name or URL of the song').setRequired(true)),
+
+    async execute(interaction) {
+        const voiceChannel = interaction.member.voice.channel;
+        if (!voiceChannel) return interaction.reply({ content: 'You must be in a voice channel!', ephemeral: true });
+
+        const songQuery = interaction.options.getString('song');
+        await interaction.deferReply();
+
+        let videoInfo;
+        try {
+            videoInfo = await ytdlp(songQuery, { dumpSingleJson: true, noWarnings: true });
+        } catch (e) {
+            return interaction.editReply('❌ Could not find the song.');
+        }
+
+        const song = {
+            title: videoInfo.title,
+            url: videoInfo.webpage_url,
+            thumbnail: videoInfo.thumbnail,
+            duration: videoInfo.duration_string,
+            requester: interaction.member,
+        };
+
+        let queue = serverQueue.get(interaction.guild.id);
+        if (!queue) {
+            const player = createAudioPlayer();
+            const queueContruct = {
+                textChannel: interaction.channel,
+                voiceChannel,
+                connection: null,
+                songs: [song],
+                player,
+                nowPlayingMessage: null,
+            };
+
+            serverQueue.set(interaction.guild.id, queueContruct);
+            try {
+                const connection = joinVoiceChannel({
+                    channelId: voiceChannel.id,
+                    guildId: interaction.guild.id,
+                    adapterCreator: interaction.guild.voiceAdapterCreator,
+                });
+                queueContruct.connection = connection;
+                const message = await interaction.editReply({ content: `⏱️ Loading song...` });
+                queueContruct.nowPlayingMessage = message;
+                play(interaction.guild, song);
+            } catch (err) {
+                console.error(err);
+                serverQueue.delete(interaction.guild.id);
+                return interaction.editReply('Could not join the voice channel.');
+            }
+        } else {
+            queue.songs.push(song);
+            return interaction.editReply(`✅ Added to queue: **${song.title}**`);
+        }
+    },
+
+    async handleButton(interaction) {
+        const queue = serverQueue.get(interaction.guild.id);
+        if (!queue) return interaction.reply({ content: 'The bot is not playing anything.', ephemeral: true });
+        if (interaction.member.voice.channel.id !== queue.voiceChannel.id) return interaction.reply({ content: 'You must be in the same voice channel!', ephemeral: true });
+
+        await interaction.deferUpdate();
+
+        switch (interaction.customId) {
+            case 'music_pause_resume':
+                queue.player.state.status === AudioPlayerStatus.Playing ? queue.player.pause() : queue.player.unpause();
+                break;
+            case 'music_skip':
+                queue.player.stop();
+                break;
+            case 'music_stop':
+                queue.songs = [];
+                queue.player.stop();
+                if(queue.connection) queue.connection.destroy();
+                serverQueue.delete(interaction.guild.id);
+                await queue.nowPlayingMessage.edit({ content: '⏹️ Music stopped and queue cleared.', embeds: [], components: [] });
+                return;
+        }
+
+        const { embed, row } = createControlPanel(queue.songs[0], queue, queue.player.state);
+        await queue.nowPlayingMessage.edit({ embeds: [embed], components: [row] });
+    },
+};

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -1,0 +1,27 @@
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const serverQueue = require('../queueManager');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('queue')
+        .setDescription('Displays the current song queue.'),
+    async execute(interaction) {
+        const queue = serverQueue.get(interaction.guild.id);
+        if (!queue || queue.songs.length === 0) {
+            return interaction.reply({ content: 'The queue is currently empty.', ephemeral: true });
+        }
+        const nowPlaying = queue.songs[0];
+        const queueList = queue.songs.slice(1).map((song, index) => {
+            return `${index + 1}. **${song.title}** - \`${song.duration}\``;
+        }).join('\n');
+
+        const queueEmbed = new EmbedBuilder()
+            .setColor('#0099ff')
+            .setTitle('🎶 Music Queue')
+            .setDescription(`**Now Playing:**\n[${nowPlaying.title}](${nowPlaying.url})\n\n**Up Next:**`)
+            .addFields({ name: '\u200B', value: queueList.length > 0 ? queueList : 'No other songs in queue' })
+            .setTimestamp();
+
+        await interaction.reply({ embeds: [queueEmbed] });
+    },
+};

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -1,0 +1,28 @@
+const { REST, Routes } = require('discord.js');
+const { clientId, guildId, token } = require('./config.json');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const commands = [];
+const commandsPath = path.join(__dirname, 'commands');
+const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith('.js'));
+
+for (const file of commandFiles) {
+    const command = require(path.join(commandsPath, file));
+    commands.push(command.data.toJSON());
+}
+
+const rest = new REST({ version: '10' }).setToken(token);
+
+(async () => {
+    try {
+        console.log(`Started refreshing ${commands.length} application (/) commands.`);
+        const data = await rest.put(
+            Routes.applicationGuildCommands(clientId, guildId),
+            { body: commands },
+        );
+        console.log(`Successfully reloaded ${data.length} application (/) commands.`);
+    } catch (error) {
+        console.error(error);
+    }
+})();

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
 } = require('discord.js');
 const dotenv = require('dotenv');
 dotenv.config();
+const { exec } = require("node:child_process");
 
 const { initBuildBattleEvent, handleJoinInteraction, rerollUserTheme } = require('./buildBattleEvent');
 const { initFishSeason } = require('./utils/fishSeasonManager');
@@ -2617,6 +2618,13 @@ function getSessionBuilderComponents(sessionId) {
 client.once('ready', async c => {
     console.log(`Logged in as ${c.user.tag}! Bot is ready at ${new Date().toISOString()}.`);
     startGitHubWebhookServer(c);
+    exec('ffmpeg -version', (error) => {
+        if (error) {
+            console.error(`❌ FFmpeg not found: ${error.message}`);
+        } else {
+            console.log(`✅ FFmpeg is available.`);
+        }
+    });
 
     try {
         await getDeployCommands()();
@@ -6804,6 +6812,18 @@ module.exports = {
                         await channel.send({ embeds: [embed] }).catch(() => {});
                     }
                     splitStealGames.delete(gameId);
+                }
+                return;
+            }
+            if (customId === "music_pause_resume" || customId === "music_skip" || customId === "music_stop") {
+                if (!interaction.isButton()) return;
+                const command = interaction.client.commands.get(interaction.message.interaction.commandName);
+                if (!command || !command.handleButton) return;
+                try {
+                    await command.handleButton(interaction);
+                } catch (error) {
+                    console.error(error);
+                    await interaction.reply({ content: "There was an error handling this button!", ephemeral: true }).catch(() => {});
                 }
                 return;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/builders": "^1.11.2",
+        "@discordjs/voice": "^0.18.0",
         "better-sqlite3": "^11.10.0",
-        "discord.js": "^14.14.1",
+        "discord.js": "^14.21.0",
         "dotenv": "^16.5.0",
         "exceljs": "^4.4.0",
         "ffmpeg-static": "^5.2.0",
         "sqlite3": "^5.1.7",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "yt-dlp-exec": "^1.0.2"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -80,9 +82,9 @@
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.0.tgz",
-      "integrity": "sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.1.tgz",
+      "integrity": "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.1",
@@ -93,7 +95,7 @@
         "discord-api-types": "^0.38.1",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -126,14 +128,39 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
+    "node_modules/@discordjs/voice": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.18.0.tgz",
+      "integrity": "sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/ws": "^8.5.12",
+        "discord-api-types": "^0.37.103",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.6.3",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/voice/node_modules/discord-api-types": {
+      "version": "0.37.120",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
+      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw==",
+      "license": "MIT"
+    },
     "node_modules/@discordjs/ws": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.2.tgz",
-      "integrity": "sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/collection": "^2.1.0",
-        "@discordjs/rest": "^2.5.0",
+        "@discordjs/rest": "^2.5.1",
         "@discordjs/util": "^1.1.0",
         "@sapphire/async-queue": "^1.5.2",
         "@types/ws": "^8.5.10",
@@ -792,6 +819,29 @@
         "node": ">= 10"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -865,24 +915,24 @@
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.19.3",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.19.3.tgz",
-      "integrity": "sha512-lncTRk0k+8Q5D3nThnODBR8fR8x2fM798o8Vsr40Krx0DjPwpZCuxxTcFMrXMQVOqM1QB9wqWgaXPg3TbmlHqA==",
+      "version": "14.21.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.21.0.tgz",
+      "integrity": "sha512-U5w41cEmcnSfwKYlLv5RJjB8Joa+QJyRwIJz5i/eg+v2Qvv6EYpCRhN9I2Rlf0900LuqSDg8edakUATrDZQncQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.11.2",
         "@discordjs/collection": "1.5.3",
         "@discordjs/formatters": "^0.6.1",
-        "@discordjs/rest": "^2.5.0",
+        "@discordjs/rest": "^2.5.1",
         "@discordjs/util": "^1.1.1",
-        "@discordjs/ws": "^1.2.2",
+        "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
         "discord-api-types": "^0.38.1",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.10.0",
         "tslib": "^2.6.3",
-        "undici": "6.21.1"
+        "undici": "6.21.3"
       },
       "engines": {
         "node": ">=18"
@@ -1002,6 +1052,29 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/expand-template": {
@@ -1149,6 +1222,18 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -1237,6 +1322,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -1369,6 +1463,27 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unix": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/is-unix/-/is-unix-2.0.10.tgz",
+      "integrity": "sha512-CcasZSEOQUoE7JHy56se4wyRhdJfjohuMWYmceSTaDY4naKyd1fpLiY8rJsIT6AKfVstQAhHJOfPx7jcUxK61Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1379,8 +1494,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
@@ -1626,6 +1740,21 @@
         "node": ">= 10"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -1812,6 +1941,26 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "license": "MIT"
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -1862,6 +2011,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npmlog": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
@@ -1886,6 +2047,21 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-map": {
@@ -1924,6 +2100,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -1948,6 +2133,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
       }
     },
     "node_modules/process-nextick-args": {
@@ -2146,12 +2357,32 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -2332,6 +2563,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2410,6 +2650,12 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -2450,9 +2696,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
-      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -2547,12 +2793,27 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -2650,6 +2911,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/yt-dlp-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/yt-dlp-exec/-/yt-dlp-exec-1.0.2.tgz",
+      "integrity": "sha512-swKtruQmGBs+Xrxy0wCZ2FxCT167EpBYIWdj/klTzNB2HrHng/qFlKo/C0WVlopbww8/uMIGQR6grXQ2ObcrAw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "dargs": "~7.0.0",
+        "execa": "~5.1.0",
+        "is-unix": "~2.0.1",
+        "mkdirp": "~1.0.4",
+        "node-fetch": "~2.6.5"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/zip-stream": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "description": "",
   "dependencies": {
     "@discordjs/builders": "^1.11.2",
+    "@discordjs/voice": "^0.18.0",
     "better-sqlite3": "^11.10.0",
-    "discord.js": "^14.14.1",
+    "discord.js": "^14.21.0",
     "dotenv": "^16.5.0",
     "exceljs": "^4.4.0",
     "ffmpeg-static": "^5.2.0",
     "sqlite3": "^5.1.7",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "yt-dlp-exec": "^1.0.2"
   }
 }

--- a/queueManager.js
+++ b/queueManager.js
@@ -1,0 +1,2 @@
+const queue = new Map();
+module.exports = queue;


### PR DESCRIPTION
## Summary
- add queue manager
- add ffmpeg availability check on startup
- support music control buttons
- add music `play` and `queue` commands
- add deployment helper
- include audio dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688856c1b374832d846674b0ff191cca