### PR TITLE
Add setup instructions and check for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@
 
 This project is a Discord bot for managing various server functions.
 
+## Setup
+
+1. Install [Node.js](https://nodejs.org/) (v16 or higher).
+2. Install Python 3 and ensure the `python` command is available in your `PATH`. `yt-dlp-exec` depends on it for music playback. On Debian-based systems you can run:
+   ```bash
+   apt-get update && apt-get install -y python3
+   ln -s $(command -v python3) /usr/local/bin/python
+   ```
+3. Install the Node.js dependencies:
+   ```bash
+   npm install
+   ```
+4. Start the bot with:
+   ```bash
+   node index.js
+   ```

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -2,4 +2,14 @@
 # Install dependencies for Maxwell Bot
 set -e
 
+# Ensure python exists for yt-dlp-exec
+if ! command -v python >/dev/null 2>&1; then
+    if command -v python3 >/dev/null 2>&1; then
+        ln -sf "$(command -v python3)" /usr/local/bin/python
+    else
+        echo "Python is required for yt-dlp-exec. Please install python3." >&2
+        exit 1
+    fi
+fi
+
 npm install


### PR DESCRIPTION
## Summary
- document setup steps including Python for `yt-dlp-exec`
- ensure `python` exists before `npm install`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `./install_deps.sh`

------
https://chatgpt.com/codex/tasks/task_e_688858a94e7c832dae62578ccfc7bd6f