### PR TITLE
Fix yt-dlp missing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,6 @@ Alternatively, run the provided **start.sh** script which will run `install_deps
 ```bash
 bash start.sh
 ```
+
+## Troubleshooting
+If you see an error like `Cannot find module 'yt-dlp-exec'`, make sure you have installed dependencies by running `npm install` or the provided `install_deps.sh` script.

--- a/commands/play.js
+++ b/commands/play.js
@@ -1,6 +1,12 @@
 const { SlashCommandBuilder, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
 const { joinVoiceChannel, createAudioPlayer, createAudioResource, getVoiceConnection, AudioPlayerStatus } = require('@discordjs/voice');
-const ytdlp = require('yt-dlp-exec');
+let ytdlp;
+try {
+    ytdlp = require('yt-dlp-exec');
+} catch (err) {
+    console.error("Missing dependency: yt-dlp-exec. Please run 'npm install' before starting the bot.");
+    throw err;
+}
 const serverQueue = require('../queueManager');
 
 function createControlPanel(song, queue, playerState) {


### PR DESCRIPTION
## Summary
- handle missing `yt-dlp-exec` dependency gracefully in `play` command
- document troubleshooting steps for missing module

## Testing
- `node -e "require('./commands/play.js');"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68885d6e4fdc832da136336c86326986