### PR TITLE
Add script for installing Node dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,20 @@ Alternatively, run the provided **start.sh** script which will run `install_deps
 bash start.sh
 ```
 
+### BotHosting.net quick setup
+
+If your hosting provider already has Node.js installed (for example, on
+BotHosting.net), you can install only the Node packages by running:
+
+```bash
+bash install_npm_deps.sh
+```
+
+Then launch the bot normally with:
+
+```bash
+node index.js
+```
+
 ## Troubleshooting
 If you see an error like `Cannot find module 'yt-dlp-exec'`, make sure you have installed dependencies by running `npm install` or the provided `install_deps.sh` script.

--- a/install_npm_deps.sh
+++ b/install_npm_deps.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Install Node.js dependencies without requiring root privileges.
+# Useful for bot-hosting environments that already provide Node.js.
+set -e
+
+if [ ! -d node_modules/yt-dlp-exec ]; then
+    echo "Installing Node.js packages..."
+    npm install
+else
+    echo "Dependencies already installed."
+fi


### PR DESCRIPTION
## Summary
- add an install_npm_deps.sh helper for hosting platforms
- document the script in the README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68885f57b0f4832d98b94125d979e9ab