### PR TITLE
Add King Chest and related rewards

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -320,6 +320,40 @@ const config = {
             ]
         },
 
+        "king_chest": {
+            id: "king_chest", name: "King Chest", type: "loot_box_item",
+            directDropWeight: 0,
+            emoji: "<:kingchest:1397836454515834890>", rarityValue: 3000000,
+            description: "A legendary chest awarded to leaderboard champions.",
+            basePrice: 0, appearanceChanceInShop: 0, stockRangeShop: [1, 1],
+            isRareForShopAlert: true,
+            isAlertWorthyByIdShop: true,
+            color: 0xFFD700,
+            numRolls: 1,
+            itemPool: []
+        },
+        "king_key": {
+            id: "king_key", name: "King Key", type: "item",
+            emoji: "<:kingkey:1399668224928252116>",
+            rarityValue: 3000000,
+            description: "Opens the mighty King Chest."
+        },
+        "giftcard_ticket_10": {
+            id: "giftcard_ticket_10", name: "10$ Giftcard Ticket", type: "item",
+            emoji: "🎫", rarityValue: 3000000,
+            description: "Redeemable for a $10 gift card."
+        },
+        "giftcard_ticket_25": {
+            id: "giftcard_ticket_25", name: "25$ Giftcard Ticket", type: "item",
+            emoji: "🎫", rarityValue: 3000000,
+            description: "Redeemable for a $25 gift card."
+        },
+        "giftcard_ticket_50": {
+            id: "giftcard_ticket_50", name: "50$ Giftcard Ticket", type: "item",
+            emoji: "🎫", rarityValue: 3000000,
+            description: "Redeemable for a $50 gift card."
+        },
+
         "xp_charm": {
             id: "xp_charm", name: "XP Charm", type: "charm_item",
             directDropWeight: 0.0001,


### PR DESCRIPTION
## Summary
- define `king_chest`, `king_key` and giftcard tickets
- expose new item IDs
- implement King Chest opening logic and key requirement
- track once-per-user King Chest and Key rewards
- restrict gifting of special items to server owner

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688887abe908832d947258e9dbbd681e