### PR TITLE
Disallow using giftcard tickets via use-item

### DIFF
--- a/index.js
+++ b/index.js
@@ -3238,7 +3238,10 @@ client.on('interactionCreate', async interaction => {
                     ITEM_IDS.DISCOUNT_25,
                     ITEM_IDS.DISCOUNT_50,
                     ITEM_IDS.DISCOUNT_100,
-                    ITEM_IDS.DAILY_SKIP_TICKET
+                    ITEM_IDS.DAILY_SKIP_TICKET,
+                    ITEM_IDS.GIFTCARD_10,
+                    ITEM_IDS.GIFTCARD_25,
+                    ITEM_IDS.GIFTCARD_50
                 ].includes(i.itemId));
                 choices = usableItems
                     .filter(item => item.name.toLowerCase().includes(searchTerm) || item.itemId.toLowerCase().includes(searchTerm))

--- a/systems.js
+++ b/systems.js
@@ -1385,6 +1385,10 @@ this.db.prepare(`
         const effectiveItemType = itemInInventory.itemType || itemMasterConfig.type;
         const itemName = itemMasterConfig.name; const itemEmoji = itemMasterConfig.emoji;
 
+        if ([this.GIFTCARD_10_ID, this.GIFTCARD_25_ID, this.GIFTCARD_50_ID].includes(itemId)) {
+            return { success: false, message: "Gift card tickets cannot be used through this command." };
+        }
+
         if (itemId === this.KING_CHEST_ID) {
             const keyInv = this.getItemFromInventory(userId, guildId, this.KING_KEY_ID);
             if (!keyInv || keyInv.quantity < 1) {


### PR DESCRIPTION
## Summary
- filter out giftcard tickets from `/use-item` autocomplete
- prevent `useItem` from using giftcard tickets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688891aaaeec832db61a1d242e54c332