### PR TITLE
Add role grant slash command

### DIFF
--- a/commands/give.js
+++ b/commands/give.js
@@ -25,6 +25,8 @@ module.exports = {
         .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageRoles),
     async execute(interaction) {
         // Logic handled centrally in index.js
-        await interaction.reply({ content: 'Processing give role command...', ephemeral: true });
+        if (!interaction.deferred && !interaction.replied) {
+            await interaction.deferReply({ ephemeral: true });
+        }
     },
 };

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -358,6 +358,23 @@ const commands = [
         default_member_permissions: PermissionsBitField.Flags.ManageGuild.toString()
     },
     {
+        name: 'give',
+        description: 'Give items such as roles to users (Staff Only).',
+        options: [
+            {
+                name: 'role',
+                description: 'Give a role to a user optionally for a limited time.',
+                type: ApplicationCommandOptionType.Subcommand,
+                options: [
+                    { name: 'role', description: 'The role to give.', type: ApplicationCommandOptionType.Role, required: true },
+                    { name: 'user', description: 'The user to receive the role.', type: ApplicationCommandOptionType.User, required: true },
+                    { name: 'time', description: 'Duration to keep the role (e.g., 7d). Leave empty for permanent.', type: ApplicationCommandOptionType.String, required: false }
+                ]
+            }
+        ],
+        default_member_permissions: PermissionsBitField.Flags.ManageRoles.toString()
+    },
+    {
         name: 'add-user',
         description: "Manage a user's items, roles, and currencies (Staff Only).",
         options: [


### PR DESCRIPTION
## Summary
- add `/give role` slash command to command deployment list
- ensure give command defers reply to avoid InteractionAlreadyReplied errors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6890ffe14940832d867eeabc7b6402a1