### PR TITLE
Replace fishing trash with single trash bag item

### DIFF
--- a/game_config.js
+++ b/game_config.js
@@ -441,25 +441,10 @@ const config = {
             description: "Simple bait for fishing.",
             basePrice: 100
         },
-        "waterbottle": {
-            id: "waterbottle", name: "Water Bottle", type: "junk",
-            emoji: "<:waterbottle:1394375998740365342>", rarityValue: 0,
-            description: "Discarded plastic bottle."
-        },
-        "newspaper": {
-            id: "newspaper", name: "Old Newspaper", type: "junk",
-            emoji: "<:newspaper:1394376024527077477>", rarityValue: 0,
-            description: "Just yesterday's news."
-        },
-        "emptycan": {
-            id: "emptycan", name: "Empty Can", type: "junk",
-            emoji: "<:emptycan:1394375984039460954>", rarityValue: 0,
-            description: "Rusty empty can."
-        },
-        "seaweed": {
-            id: "seaweed", name: "Seaweed", type: "junk",
-            emoji: "<:seaweed:1394375962094735390>", rarityValue: 0,
-            description: "Slimy seaweed."
+        "trashbag": {
+            id: "trashbag", name: "Trash Bag", type: "junk",
+            emoji: "<:trashbag:1402668776637464608>", rarityValue: 0,
+            description: "A bag filled with assorted trash."
         }
     },
     badges: {

--- a/index.js
+++ b/index.js
@@ -87,10 +87,7 @@ const ITEM_IDS = {
     DISCOUNT_25: gameConfig.items.discount_ticket_25?.id || 'discount_ticket_25',
     DISCOUNT_50: gameConfig.items.discount_ticket_50?.id || 'discount_ticket_50',
     DISCOUNT_100: gameConfig.items.discount_ticket_100?.id || 'discount_ticket_100',
-    WATER_BOTTLE: gameConfig.items.waterbottle?.id || 'waterbottle',
-    NEWSPAPER: gameConfig.items.newspaper?.id || 'newspaper',
-    EMPTY_CAN: gameConfig.items.emptycan?.id || 'emptycan',
-    SEAWEED: gameConfig.items.seaweed?.id || 'seaweed',
+    TRASH_BAG: gameConfig.items.trashbag?.id || 'trashbag',
 };
 
 const NON_USABLE_ITEM_IDS = [
@@ -730,13 +727,14 @@ function pickRandomFish() {
 }
 
 function pickRandomTrash() {
-    const trash = [
-        gameConfig.items.waterbottle,
-        gameConfig.items.newspaper,
-        gameConfig.items.emptycan,
-        gameConfig.items.seaweed,
+    const displayTrash = [
+        { name: 'Empty Bottle', emoji: '<:junkemptybottle:1402668764985561139>' },
+        { name: 'Empty Can', emoji: '<:junkemptycan:1402668752415490109>' },
+        { name: 'Newspaper', emoji: '<:junknewspaper:1402668741371887687>' },
+        { name: 'Plastic Bag', emoji: '<:junkplasticbag:1402668727312322685>' }
     ];
-    return trash[Math.floor(Math.random() * trash.length)];
+    const chosen = displayTrash[Math.floor(Math.random() * displayTrash.length)];
+    return { id: gameConfig.items.trashbag.id, name: chosen.name, emoji: chosen.emoji };
 }
 
 function buildFishInventoryEmbed(userId, guildId, page = 1, favoritesOnly = false) {


### PR DESCRIPTION
## Summary
- Add new `Trash Bag` item and remove legacy fishing trash items
- Show random trash types when fishing but always grant a trash bag

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68936f9fb548832da36fdadbc1494eec