### PR TITLE
feat: expand admin weather and event commands

### DIFF
--- a/commands/start-event.js
+++ b/commands/start-event.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
-const { startBlossom } = require('../utils/weatherManager');
+const { startBlossom, startPrismaticTide, startEclipse, startAurora } = require('../utils/weatherManager');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -10,24 +10,50 @@ module.exports = {
                 .setDescription('Event ID')
                 .setRequired(true)
                 .addChoices(
-                    { name: 'Cherry Blossom Breeze', value: 'blossom' }
+                    { name: 'Cherry Blossom Breeze', value: 'blossom' },
+                    { name: 'Prismatic Tide', value: 'prismatic' },
+                    { name: 'Eclipse', value: 'eclipse' },
+                    { name: 'Aurora', value: 'aurora' }
                 )
         )
         .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
     async execute(interaction) {
         const id = interaction.options.getString('id');
         let response;
+        let result;
         if (id === 'blossom') {
-            const result = await startBlossom(interaction.client, { byAdmin: true });
-            if (!result.started) {
-                const endTs = Math.floor((Date.now() + result.remaining) / 1000);
-                response = { content: `The event Cherry Blossom Breeze is currently active, you can use again in <t:${endTs}:R>`, ephemeral: true };
-            } else {
-                response = { content: 'Cherry Blossom Breeze started.', ephemeral: true };
-            }
+            result = await startBlossom(interaction.client, { byAdmin: true });
+        } else if (id === 'prismatic') {
+            result = await startPrismaticTide(interaction.client, { byAdmin: true });
+        } else if (id === 'eclipse') {
+            result = await startEclipse(interaction.client, { byAdmin: true });
+        } else if (id === 'aurora') {
+            result = await startAurora(interaction.client, { byAdmin: true });
         } else {
             response = { content: 'Unknown event ID.', ephemeral: true };
         }
+
+        if (!response) {
+            if (!result.started) {
+                const endTs = Math.floor((Date.now() + result.remaining) / 1000);
+                const nameMap = {
+                    blossom: 'Cherry Blossom Breeze',
+                    prismatic: 'Prismatic Tide',
+                    eclipse: 'Eclipse',
+                    aurora: 'Aurora'
+                };
+                response = { content: `The event ${nameMap[id]} is currently active, you can use again in <t:${endTs}:R>`, ephemeral: true };
+            } else {
+                const nameMap = {
+                    blossom: 'Cherry Blossom Breeze',
+                    prismatic: 'Prismatic Tide',
+                    eclipse: 'Eclipse',
+                    aurora: 'Aurora'
+                };
+                response = { content: `${nameMap[id]} started.`, ephemeral: true };
+            }
+        }
+
         if (interaction.deferred || interaction.replied) return interaction.editReply(response);
         return interaction.reply(response);
     },

--- a/commands/start-weather.js
+++ b/commands/start-weather.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, PermissionsBitField } = require('discord.js');
-const { startRain } = require('../utils/weatherManager');
+const { startRain, startGoldenRain, startSnowRain, startSolarFlare } = require('../utils/weatherManager');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -10,24 +10,50 @@ module.exports = {
                 .setDescription('Weather ID')
                 .setRequired(true)
                 .addChoices(
-                    { name: 'Rain', value: 'rain' }
+                    { name: 'Rain', value: 'rain' },
+                    { name: 'Golden Rain', value: 'goldenRain' },
+                    { name: 'Snow Rain', value: 'snowRain' },
+                    { name: 'Solar Flare Surge', value: 'solarFlare' }
                 )
         )
         .setDefaultMemberPermissions(PermissionsBitField.Flags.ManageGuild),
     async execute(interaction) {
         const id = interaction.options.getString('id');
         let response;
+        let result;
         if (id === 'rain') {
-            const result = await startRain(interaction.client, { byAdmin: true });
-            if (!result.started) {
-                const endTs = Math.floor((Date.now() + result.remaining) / 1000);
-                response = { content: `The weather Rain is already active, you can activate again in <t:${endTs}:R>`, ephemeral: true };
-            } else {
-                response = { content: 'Rain has started.', ephemeral: true };
-            }
+            result = await startRain(interaction.client, { byAdmin: true });
+        } else if (id === 'goldenRain') {
+            result = await startGoldenRain(interaction.client, { byAdmin: true });
+        } else if (id === 'snowRain') {
+            result = await startSnowRain(interaction.client, { byAdmin: true });
+        } else if (id === 'solarFlare') {
+            result = await startSolarFlare(interaction.client, { byAdmin: true });
         } else {
             response = { content: 'Unknown weather ID.', ephemeral: true };
         }
+
+        if (!response) {
+            if (!result.started) {
+                const endTs = Math.floor((Date.now() + result.remaining) / 1000);
+                const nameMap = {
+                    rain: 'Rain',
+                    goldenRain: 'Golden Rain',
+                    snowRain: 'Snow Rain',
+                    solarFlare: 'Solar Flare Surge'
+                };
+                response = { content: `The weather ${nameMap[id]} is already active, you can activate again in <t:${endTs}:R>`, ephemeral: true };
+            } else {
+                const nameMap = {
+                    rain: 'Rain',
+                    goldenRain: 'Golden Rain',
+                    snowRain: 'Snow Rain',
+                    solarFlare: 'Solar Flare Surge'
+                };
+                response = { content: `${nameMap[id]} has started.`, ephemeral: true };
+            }
+        }
+
         if (interaction.deferred || interaction.replied) return interaction.editReply(response);
         return interaction.reply(response);
     },


### PR DESCRIPTION
## Summary
- expand /start-event to include Prismatic Tide, Eclipse, and Aurora
- add Golden Rain, Snow Rain, and Solar Flare Surge to /start-weather

## Testing
- `node --check commands/start-event.js`
- `node --check commands/start-weather.js`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6893845f1248832dbf2c7ab31e52d8f6