### PR TITLE
fix: remove emoji from slash command

### DIFF
--- a/commands/trick-or-treat.js
+++ b/commands/trick-or-treat.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('trick-or-treat🎃')
+        .setName('trick-or-treat')
         .setDescription('Go trick-or-treating for candies.'),
     async execute(interaction) {
         await interaction.reply({ content: 'Trick-or-treating...', ephemeral: false });


### PR DESCRIPTION
## Summary
- remove pumpkin emoji from trick-or-treat slash command name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689450f5a4f8832db0d289e14a30f608