### PR TITLE
Fix slash command name for Discord compatibility

### DIFF
--- a/deployCommands.js
+++ b/deployCommands.js
@@ -714,7 +714,7 @@ const commands = [
         ]
     },
     {
-        name: 'trick-or-treat🎃',
+        name: 'trick-or-treat',
         description: 'Knock on a door for a Halloween surprise.'
     },
 ];

--- a/index.js
+++ b/index.js
@@ -3929,7 +3929,7 @@ module.exports = {
                 return;
                 }
             }
-            if (commandName === 'trick-or-treat🎃') {
+            if (commandName === 'trick-or-treat') {
                 if (interaction.channelId !== TRICK_OR_TREAT_CHANNEL_ID) {
                     return sendInteractionError(interaction, 'This command can only be used in the trick-or-treat channel.', true);
                 }


### PR DESCRIPTION
## Summary
- Remove emoji from `trick-or-treat` command name to comply with Discord slash command rules
- Update command handling logic accordingly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689460ddf238832d8d6d3107346bb422