### PR TITLE
Restrict Blossom event to spring season

### DIFF
--- a/commands/start-event.js
+++ b/commands/start-event.js
@@ -35,14 +35,18 @@ module.exports = {
 
         if (!response) {
             if (!result.started) {
-                const endTs = Math.floor((Date.now() + result.remaining) / 1000);
-                const nameMap = {
-                    blossom: 'Cherry Blossom Breeze',
-                    prismatic: 'Prismatic Tide',
-                    eclipse: 'Eclipse',
-                    aurora: 'Aurora'
-                };
-                response = { content: `The event ${nameMap[id]} is currently active, you can use again in <t:${endTs}:R>`, ephemeral: true };
+                if (result.seasonMismatch && id === 'blossom') {
+                    response = { content: 'Cherry Blossom Breeze can only be started during the Spring season.', ephemeral: true };
+                } else {
+                    const endTs = Math.floor((Date.now() + result.remaining) / 1000);
+                    const nameMap = {
+                        blossom: 'Cherry Blossom Breeze',
+                        prismatic: 'Prismatic Tide',
+                        eclipse: 'Eclipse',
+                        aurora: 'Aurora'
+                    };
+                    response = { content: `The event ${nameMap[id]} is currently active, you can use again in <t:${endTs}:R>`, ephemeral: true };
+                }
             } else {
                 const nameMap = {
                     blossom: 'Cherry Blossom Breeze',

--- a/utils/weatherManager.js
+++ b/utils/weatherManager.js
@@ -201,6 +201,10 @@ async function startSnowRain(client, opts = {}) {
 }
 
 async function startBlossom(client, opts = {}) {
+    const seasonIndex = typeof client.getCurrentSeasonIndex === 'function' ? client.getCurrentSeasonIndex() : -1;
+    if (seasonIndex !== 0) {
+        return { started: false, remaining: 0, seasonMismatch: true };
+    }
     if (active.blossom) {
         return { started: false, remaining: Math.max(0, activeUntil.blossom - Date.now()) };
     }
@@ -272,7 +276,7 @@ async function startAurora(client, opts = {}) {
 
 async function rollWeather(client) {
     if (!active.rain && !active.goldenRain && !active.snowRain && Math.random() < 0.1) await startRain(client);
-    const seasonIndex = typeof client.getCurrentSeasonIndex === 'function' ? client.getCurrentSeasonIndex() : 0;
+    const seasonIndex = typeof client.getCurrentSeasonIndex === 'function' ? client.getCurrentSeasonIndex() : -1;
     if (seasonIndex === 0 && !active.blossom && Math.random() < 0.1) await startBlossom(client);
     if (!active.prismatic && Math.random() < 0.01) await startPrismaticTide(client);
     if (seasonIndex === 1 && isDay() && !active.solarFlare && Math.random() < 0.35) await startSolarFlare(client);


### PR DESCRIPTION
## Summary
- ensure Cherry Blossom Breeze only activates during the spring season
- prevent seasonal events from triggering before season data is available
- warn staff when attempting to start Blossom outside spring

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68947248f7f4832d9c2e8adbb5a71be6