### PR TITLE
Add Python bot to unregister slash commands on startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,22 @@
+import os
+import discord
+from discord import app_commands
+
+COMMAND_TO_REMOVE = os.getenv("COMMAND_TO_REMOVE", "command_name")
+GUILD_ID = int(os.getenv("GUILD_ID", "0")) or None
+
+class MyBot(discord.Client):
+    def __init__(self):
+        super().__init__(intents=discord.Intents.default())
+        self.tree = app_commands.CommandTree(self)
+
+    async def setup_hook(self):
+        guild = discord.Object(id=GUILD_ID) if GUILD_ID else None
+        self.tree.remove_command(COMMAND_TO_REMOVE, guild=guild)
+        await self.tree.sync(guild=guild)
+
+    async def on_ready(self):
+        print(f"Logged in as {self.user}")
+
+bot = MyBot()
+bot.run(os.getenv("TOKEN"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord.py


### PR DESCRIPTION
## Summary
- add Python bot example that unregisters a removed slash command on startup
- define Python dependency for discord.py

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68962edc838083218edc07f7f586681a