### PR TITLE
Use Discord avatars in /level and cache image assets

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -32,10 +32,11 @@ def main() -> None:
     @tree.command(name="level", description="Show your level card")
     async def level_command(interaction: discord.Interaction):
         await interaction.response.defer()
-        avatar_hash = (
-            interaction.user.avatar.key if interaction.user.avatar else None
+        avatar_url = (
+            interaction.user.display_avatar.replace(
+                size=256, static_format="png"
+            ).url
         )
-        avatar_url = None if avatar_hash else interaction.user.display_avatar.url
         path = render_level_card(
             username=interaction.user.name,
             nickname=getattr(interaction.user, "display_name", interaction.user.name),
@@ -46,8 +47,6 @@ def main() -> None:
             prestige=0,
             total_xp=0,
             avatar_url=avatar_url,
-            discord_user_id=str(interaction.user.id),
-            discord_avatar_hash=avatar_hash,
             outfile=f"level_{interaction.user.id}.png",
         )
         await interaction.followup.send(file=discord.File(path))


### PR DESCRIPTION
## Summary
- Use the requesting user's Discord avatar when rendering level cards
- Cache image fetching helpers to avoid repeated network downloads

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689648a272848321b769909e73bbb544