### PR TITLE
Add card settings modal for level command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,11 +1,19 @@
 import os
 from io import BytesIO
+from typing import Any
 
 import discord
 from discord import app_commands
 from dotenv import load_dotenv
 from PIL import Image
 from level_card import render_level_card
+from urllib.request import urlopen
+import urllib.parse
+
+user_card_settings: dict[int, dict[str, Any]] = {}
+DEFAULT_COLOR = (92, 220, 140)
+DEFAULT_BACKGROUND = "https://i.ibb.co/9337ZnxF/wdwdwd.jpg"
+CARD_SETTING_EMOJI = discord.PartialEmoji(name="JAGGear", id=1403607883786223759)
 
 
 def main() -> None:
@@ -18,6 +26,66 @@ def main() -> None:
     intents = discord.Intents.default()
     client = discord.Client(intents=intents)
     tree = app_commands.CommandTree(client)
+
+    class CardSettingsModal(discord.ui.Modal):
+        def __init__(self, color: tuple[int, int, int], background_url: str) -> None:
+            super().__init__(title="Card Settings")
+            self.color_input = discord.ui.TextInput(
+                label="Color [RGB]", default=f"{color[0]},{color[1]},{color[2]}"
+            )
+            self.bg_input = discord.ui.TextInput(
+                label="Background URL", default=background_url
+            )
+            self.add_item(self.color_input)
+            self.add_item(self.bg_input)
+
+        async def on_submit(self, interaction: discord.Interaction) -> None:
+            try:
+                parts = [int(p.strip()) for p in self.color_input.value.split(",")]
+                if len(parts) != 3 or not all(0 <= c <= 255 for c in parts):
+                    raise ValueError
+            except Exception:
+                await interaction.response.send_message(
+                    "Invalid color. Use R,G,B between 0-255.", ephemeral=True
+                )
+                return
+            url = self.bg_input.value.strip()
+            try:
+                parsed = urllib.parse.urlparse(url)
+                if parsed.scheme not in ("http", "https"):
+                    raise ValueError
+                with urlopen(url) as r:
+                    r.read(1)
+            except Exception:
+                await interaction.response.send_message(
+                    "Invalid background URL.", ephemeral=True
+                )
+                return
+            user_card_settings[interaction.user.id] = {
+                "color": tuple(parts),
+                "background_url": url,
+            }
+            await interaction.response.send_message(
+                "Card settings updated.", ephemeral=True
+            )
+
+    class CardSettingsView(discord.ui.View):
+        def __init__(self, color: tuple[int, int, int], background_url: str) -> None:
+            super().__init__(timeout=None)
+            self.color = color
+            self.background_url = background_url
+
+        @discord.ui.button(
+            label="Card Setting",
+            style=discord.ButtonStyle.gray,
+            emoji=CARD_SETTING_EMOJI,
+        )
+        async def card_setting(
+            self, interaction: discord.Interaction, button: discord.ui.Button
+        ) -> None:
+            await interaction.response.send_modal(
+                CardSettingsModal(self.color, self.background_url)
+            )
 
     @client.event
     async def on_ready():
@@ -35,6 +103,13 @@ def main() -> None:
     @tree.command(name="level", description="Show your level card")
     async def level_command(interaction: discord.Interaction):
         await interaction.response.defer()
+        user_id = interaction.user.id
+        settings = user_card_settings.setdefault(
+            user_id,
+            {"color": DEFAULT_COLOR, "background_url": DEFAULT_BACKGROUND},
+        )
+        color = settings["color"]
+        background_url = settings["background_url"]
         avatar_asset = (
             interaction.user.display_avatar.with_size(256).with_static_format("png")
         )
@@ -50,9 +125,12 @@ def main() -> None:
             prestige=0,
             total_xp=0,
             avatar_image=avatar_image,
-            outfile=f"level_{interaction.user.id}.png",
+            background_url=background_url,
+            bar_color=color,
+            outfile=f"level_{user_id}.png",
         )
-        await interaction.followup.send(file=discord.File(path))
+        view = CardSettingsView(color, background_url)
+        await interaction.followup.send(file=discord.File(path), view=view)
         try:
             os.remove(path)
         except OSError:

--- a/level_card.py
+++ b/level_card.py
@@ -249,6 +249,7 @@ def render_level_card(
     badges: tuple[str | None, str | None, str | None] = (None, None, None),
     stats_offset: int = 50,
     bar_opacity: float = 0.55,
+    bar_color: tuple[int, int, int] = (92, 220, 140),
     avatar_url: str | None = None,
     discord_user_id: str | None = None,
     discord_avatar_hash: str | None = None,
@@ -303,7 +304,8 @@ def render_level_card(
 
     bar_rect = (info_x, 156, W - pad, 204)
     p = 0 if xp_total <= 0 else max(0, min(1, xp / xp_total))
-    progress_bar(base, bar_rect, p, bar_opacity=bar_opacity)
+    dark = tuple(max(0, min(255, c - 60)) for c in bar_color)
+    progress_bar(base, bar_rect, p, c0=bar_color, c1=dark, bar_opacity=bar_opacity)
 
     # Star + XP text
     try:


### PR DESCRIPTION
## Summary
- add per-user card settings for color and background
- provide modal with color and background URL inputs via gear button in `/level`
- allow custom progress bar color on level card

## Testing
- `python -m py_compile bot.py level_card.py`


------
https://chatgpt.com/codex/tasks/task_e_6896dab13fd88321b0443beda1bd7765