### PR TITLE
Implement XP system and voice rewards

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,11 +9,44 @@ from PIL import Image
 from level_card import render_level_card
 from urllib.request import urlopen
 import urllib.parse
+import random
+from datetime import datetime
 
 user_card_settings: dict[int, dict[str, Any]] = {}
+user_stats: dict[int, dict[str, int]] = {}
+voice_sessions: dict[int, datetime] = {}
 DEFAULT_COLOR = (92, 220, 140)
 DEFAULT_BACKGROUND = "https://i.ibb.co/9337ZnxF/wdwdwd.jpg"
 CARD_SETTING_EMOJI = discord.PartialEmoji(name="Botgear", id=1403611995814629447)
+XP_EMOJI = "<:xp:1403665761825980457>"
+REPLY = "<:reply:1403665761825980456>"
+REPLY1 = "<:reply1:1403665779404050562>"
+LEVEL_UP_CHANNEL_ID = 1373578620634665052
+MAX_LEVEL = 9999
+
+def xp_needed(level: int) -> int:
+    return int(100 * (level ** 1.5))
+
+
+async def add_xp(user: discord.abc.User, amount: int, client: discord.Client) -> None:
+    stats = user_stats.setdefault(user.id, {"level": 1, "xp": 0, "total_xp": 0})
+    stats["xp"] += amount
+    stats["total_xp"] += amount
+    prev_level = stats["level"]
+    while stats["level"] < MAX_LEVEL and stats["xp"] >= xp_needed(stats["level"]):
+        stats["xp"] -= xp_needed(stats["level"])
+        stats["level"] += 1
+    if stats["level"] >= MAX_LEVEL:
+        stats["xp"] = 0
+    if stats["level"] > prev_level:
+        channel = client.get_channel(LEVEL_UP_CHANNEL_ID)
+        if channel:
+            embed = discord.Embed(
+                color=0xFFFFFF,
+                title="Leveled up",
+                description=f"{user.mention} have leveled up from level {prev_level} to {stats['level']}",
+            )
+            await channel.send(embed=embed)
 
 
 def main() -> None:
@@ -24,6 +57,8 @@ def main() -> None:
         raise RuntimeError("BOT_TOKEN not set in environment")
 
     intents = discord.Intents.default()
+    intents.message_content = True
+    intents.voice_states = True
     client = discord.Client(intents=intents)
     tree = app_commands.CommandTree(client)
 
@@ -74,17 +109,20 @@ def main() -> None:
             avatar_bytes = await avatar_asset.read()
             avatar_image = Image.open(BytesIO(avatar_bytes)).convert("RGBA")
             try:
+                stats = user_stats.setdefault(
+                    interaction.user.id, {"level": 1, "xp": 0, "total_xp": 0}
+                )
                 path = render_level_card(
                     username=interaction.user.name,
                     nickname=getattr(
                         interaction.user, "display_name", interaction.user.name
                     ),
-                    level=1,
-                    xp=0,
-                    xp_total=100,
+                    level=stats["level"],
+                    xp=stats["xp"],
+                    xp_total=xp_needed(stats["level"]),
                     rank=0,
                     prestige=0,
-                    total_xp=0,
+                    total_xp=stats["total_xp"],
                     avatar_image=avatar_image,
                     background_url=url,
                     bar_color=tuple(parts),
@@ -99,7 +137,7 @@ def main() -> None:
                 "color": tuple(parts),
                 "background_url": url,
             }
-            view = CardSettingsView(tuple(parts), url)
+            view = CardSettingsView(tuple(parts), url, interaction.user.id)
             await self.message.edit(attachments=[discord.File(path)], view=view)
             try:
                 os.remove(path)
@@ -110,10 +148,21 @@ def main() -> None:
             )
 
     class CardSettingsView(discord.ui.View):
-        def __init__(self, color: tuple[int, int, int], background_url: str) -> None:
+        def __init__(
+            self, color: tuple[int, int, int], background_url: str, owner_id: int
+        ) -> None:
             super().__init__(timeout=None)
             self.color = color
             self.background_url = background_url
+            self.owner_id = owner_id
+
+        async def interaction_check(self, interaction: discord.Interaction) -> bool:
+            if interaction.user.id != self.owner_id:
+                await interaction.response.send_message(
+                    "You can't interact with this command.", ephemeral=True
+                )
+                return False
+            return True
 
         @discord.ui.button(
             label="Card Setting",
@@ -137,8 +186,41 @@ def main() -> None:
     async def on_message(message: discord.Message):
         if message.author == client.user:
             return
+        await add_xp(message.author, random.randint(1, 10), client)
         if message.content == "!ping":
             await message.channel.send("Pong!")
+
+    @client.event
+    async def on_voice_state_update(
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if before.channel is None and after.channel is not None:
+            voice_sessions[member.id] = datetime.utcnow()
+        elif before.channel is not None and after.channel is None:
+            start = voice_sessions.pop(member.id, None)
+            if start:
+                duration = datetime.utcnow() - start
+                minutes = int(duration.total_seconds() // 60)
+                if minutes > 0:
+                    xp = sum(random.randint(1, 3) for _ in range(minutes))
+                    await add_xp(member, xp, client)
+                    channel = client.get_channel(LEVEL_UP_CHANNEL_ID)
+                    if channel:
+                        desc = (
+                            f"Hey {member.mention}, while you in Voice-chat you earned:\n"
+                            f"{REPLY} {XP_EMOJI} {xp}"
+                        )
+                        embed = discord.Embed(
+                            color=0xFFFFFF,
+                            title="Voice Chat Reward Conclusion",
+                            description=desc,
+                        )
+                        embed.set_footer(
+                            text=f"Total Voice Time: {str(duration).split('.')[0]}"
+                        )
+                        await channel.send(embed=embed)
 
     @tree.command(name="level", description="Show your level card")
     async def level_command(interaction: discord.Interaction):
@@ -156,39 +238,42 @@ def main() -> None:
         avatar_bytes = await avatar_asset.read()
         avatar_image = Image.open(BytesIO(avatar_bytes)).convert("RGBA")
         try:
+            stats = user_stats.setdefault(
+                user_id, {"level": 1, "xp": 0, "total_xp": 0}
+            )
             path = render_level_card(
                 username=interaction.user.name,
                 nickname=getattr(interaction.user, "display_name", interaction.user.name),
-                level=1,
-                xp=0,
-                xp_total=100,
+                level=stats["level"],
+                xp=stats["xp"],
+                xp_total=xp_needed(stats["level"]),
                 rank=0,
                 prestige=0,
-                total_xp=0,
+                total_xp=stats["total_xp"],
                 avatar_image=avatar_image,
                 background_url=background_url,
                 bar_color=color,
                 outfile=f"level_{user_id}.png",
             )
-            view = CardSettingsView(color, background_url)
+            view = CardSettingsView(color, background_url, interaction.user.id)
             await interaction.followup.send(file=discord.File(path), view=view)
         except ValueError:
             settings["background_url"] = DEFAULT_BACKGROUND
             path = render_level_card(
                 username=interaction.user.name,
                 nickname=getattr(interaction.user, "display_name", interaction.user.name),
-                level=1,
-                xp=0,
-                xp_total=100,
+                level=stats["level"],
+                xp=stats["xp"],
+                xp_total=xp_needed(stats["level"]),
                 rank=0,
                 prestige=0,
-                total_xp=0,
+                total_xp=stats["total_xp"],
                 avatar_image=avatar_image,
                 background_url=DEFAULT_BACKGROUND,
                 bar_color=color,
                 outfile=f"level_{user_id}.png",
             )
-            view = CardSettingsView(color, DEFAULT_BACKGROUND)
+            view = CardSettingsView(color, DEFAULT_BACKGROUND, interaction.user.id)
             await interaction.followup.send(
                 "Background image invalid; using default.",
                 file=discord.File(path),


### PR DESCRIPTION
## Summary
- Add XP and level tracking with cap and level-up announcements
- Grant random XP for messages and voice chat participation with alert embeds
- Limit card settings interactions to the invoking user

## Testing
- `python -m py_compile bot.py level_card.py`


------
https://chatgpt.com/codex/tasks/task_e_689710f19270832187d8a920c1fa0afa