### PR TITLE
feat: persist user level data and card design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 .env
 *.pyc
 venv/
+user_data.json

--- a/README.md
+++ b/README.md
@@ -25,3 +25,6 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
    ```
 
 The bot will respond to `!ping` messages with `Pong!`.
+
+User level statistics and card design preferences are stored in
+`user_data.json` so they persist between restarts.


### PR DESCRIPTION
## Summary
- store user stats and level card settings in `user_data.json`
- load saved data on startup and save after updates
- document persistence and ignore generated data file

## Testing
- `python -m py_compile bot.py level_card.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689715c41b1c8321be29b99959a14709