### PR TITLE
Persist timed roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
 The bot will respond to `!ping` messages with `Pong!`.
 
 A slash command `/add-role` can give a role to a user, optionally for a
-limited time (`1h`, `1d`, `7w`, `1m`).
+limited time (`1h`, `1d`, `7w`, `1m`). Timed roles are stored so they persist
+even if the bot restarts.
 
 User level statistics and card design preferences are stored in
 `user_data.json` so they persist between restarts.

--- a/command/add_role.py
+++ b/command/add_role.py
@@ -1,7 +1,6 @@
-import asyncio
-
 import discord
 from discord import app_commands
+from datetime import datetime
 
 
 def parse_duration(time_str: str) -> int | None:
@@ -17,6 +16,7 @@ def parse_duration(time_str: str) -> int | None:
 
 def setup(tree, *_, **__):
     """Register the add-role command with the provided command tree."""
+    schedule_role = __["schedule_role"]
 
     @tree.command(
         name="add-role", description="Give a role to a user, optionally for a limited time"
@@ -60,11 +60,11 @@ def setup(tree, *_, **__):
                 )
                 return
 
-            async def remove_later() -> None:
-                await asyncio.sleep(seconds)
-                try:
-                    await user.remove_roles(role)
-                except discord.HTTPException:
-                    pass
-
-            asyncio.create_task(remove_later())
+            expires_at = datetime.utcnow().timestamp() + seconds
+            schedule_role(
+                user.id,
+                interaction.guild.id,
+                role.id,
+                expires_at,
+                save=True,
+            )

--- a/command/level.py
+++ b/command/level.py
@@ -13,7 +13,8 @@ def setup(tree,
           DEFAULT_COLOR,
           DEFAULT_BACKGROUND,
           render_level_card,
-          CardSettingsView):
+          CardSettingsView,
+          **__):
     """Register the level command with the provided command tree."""
 
     @tree.command(name="level", description="Show your level card")


### PR DESCRIPTION
## Summary
- Persist `/add-role` timers by saving role assignments and scheduling removal
- Load stored timers on startup and register removal tasks
- Document timed role persistence

## Testing
- `python -m py_compile bot.py command/add_role.py command/level.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689794af40508321857dfb017be4c8c0