### PR TITLE
feat: add prefix level command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
 
 The bot will respond to `!ping` messages with `Pong!`.
 
+The level card can also be requested with the `a.` or `A.` prefix. For example,
+you can type `a. level` or `A.level` to see your card.
+
 A slash command `/add-role` can give a role to a user, optionally for a
 limited time (`1h`, `1d`, `7w`, `1m`). Timed roles are stored so they persist
 even if the bot restarts.

--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,7 @@ from urllib.request import urlopen
 import urllib.parse
 import random
 from datetime import datetime
+from command.level import send_level_card
 
 DATA_FILE = "user_data.json"
 user_card_settings: dict[int, dict[str, Any]] = {}
@@ -274,6 +275,25 @@ def main() -> None:
         if message.author == client.user:
             return
         await add_xp(message.author, random.randint(1, 10), client)
+        content = message.content.strip()
+        lower = content.lower()
+        if lower.startswith("a."):
+            cmd = lower[2:].lstrip()
+            if cmd == "level":
+                await send_level_card(
+                    message.author,
+                    message.channel.send,
+                    user_stats,
+                    user_card_settings,
+                    save_data,
+                    xp_needed,
+                    DEFAULT_COLOR,
+                    DEFAULT_BACKGROUND,
+                    render_level_card,
+                    CardSettingsView,
+                    allow_ephemeral=False,
+                )
+                return
         if message.content == "!ping":
             await message.channel.send("Pong!")
 

--- a/command/level.py
+++ b/command/level.py
@@ -5,79 +5,116 @@ import discord
 from PIL import Image
 
 
-def setup(tree,
-          user_stats,
-          user_card_settings,
-          save_data,
-          xp_needed,
-          DEFAULT_COLOR,
-          DEFAULT_BACKGROUND,
-          render_level_card,
-          CardSettingsView,
-          **__):
-    """Register the level command with the provided command tree."""
-
-    @tree.command(name="level", description="Show your level card")
-    async def level_command(interaction: discord.Interaction):
-        await interaction.response.defer()
-        user_id = interaction.user.id
-        settings = user_card_settings.setdefault(
-            user_id, {"color": DEFAULT_COLOR, "background_url": DEFAULT_BACKGROUND}
+async def send_level_card(
+    user,
+    send,
+    user_stats,
+    user_card_settings,
+    save_data,
+    xp_needed,
+    DEFAULT_COLOR,
+    DEFAULT_BACKGROUND,
+    render_level_card,
+    CardSettingsView,
+    *,
+    allow_ephemeral: bool = False,
+):
+    """Render and send a user's level card."""
+    user_id = user.id
+    settings = user_card_settings.setdefault(
+        user_id, {"color": DEFAULT_COLOR, "background_url": DEFAULT_BACKGROUND}
+    )
+    stats = user_stats.setdefault(
+        user_id, {"level": 1, "xp": 0, "total_xp": 0}
+    )
+    save_data()
+    color = settings["color"]
+    background_url = settings["background_url"]
+    avatar_asset = user.display_avatar.with_size(256).with_static_format("png")
+    avatar_bytes = await avatar_asset.read()
+    avatar_image = Image.open(BytesIO(avatar_bytes)).convert("RGBA")
+    try:
+        path = render_level_card(
+            username=user.name,
+            nickname=getattr(user, "display_name", user.name),
+            level=stats["level"],
+            xp=stats["xp"],
+            xp_total=xp_needed(stats["level"]),
+            rank=0,
+            prestige=0,
+            total_xp=stats["total_xp"],
+            avatar_image=avatar_image,
+            background_url=background_url,
+            bar_color=color,
+            outfile=f"level_{user_id}.png",
         )
-        stats = user_stats.setdefault(
-            user_id, {"level": 1, "xp": 0, "total_xp": 0}
-        )
+        view = CardSettingsView(color, background_url, user_id)
+        await send(file=discord.File(path), view=view)
+    except ValueError:
+        settings["background_url"] = DEFAULT_BACKGROUND
         save_data()
-        color = settings["color"]
-        background_url = settings["background_url"]
-        avatar_asset = (
-            interaction.user.display_avatar.with_size(256).with_static_format("png")
+        path = render_level_card(
+            username=user.name,
+            nickname=getattr(user, "display_name", user.name),
+            level=stats["level"],
+            xp=stats["xp"],
+            xp_total=xp_needed(stats["level"]),
+            rank=0,
+            prestige=0,
+            total_xp=stats["total_xp"],
+            avatar_image=avatar_image,
+            background_url=DEFAULT_BACKGROUND,
+            bar_color=color,
+            outfile=f"level_{user_id}.png",
         )
-        avatar_bytes = await avatar_asset.read()
-        avatar_image = Image.open(BytesIO(avatar_bytes)).convert("RGBA")
-        try:
-            path = render_level_card(
-                username=interaction.user.name,
-                nickname=getattr(interaction.user, "display_name", interaction.user.name),
-                level=stats["level"],
-                xp=stats["xp"],
-                xp_total=xp_needed(stats["level"]),
-                rank=0,
-                prestige=0,
-                total_xp=stats["total_xp"],
-                avatar_image=avatar_image,
-                background_url=background_url,
-                bar_color=color,
-                outfile=f"level_{user_id}.png",
-            )
-            view = CardSettingsView(color, background_url, interaction.user.id)
-            await interaction.followup.send(file=discord.File(path), view=view)
-        except ValueError:
-            settings["background_url"] = DEFAULT_BACKGROUND
-            save_data()
-            path = render_level_card(
-                username=interaction.user.name,
-                nickname=getattr(interaction.user, "display_name", interaction.user.name),
-                level=stats["level"],
-                xp=stats["xp"],
-                xp_total=xp_needed(stats["level"]),
-                rank=0,
-                prestige=0,
-                total_xp=stats["total_xp"],
-                avatar_image=avatar_image,
-                background_url=DEFAULT_BACKGROUND,
-                bar_color=color,
-                outfile=f"level_{user_id}.png",
-            )
-            view = CardSettingsView(color, DEFAULT_BACKGROUND, interaction.user.id)
-            await interaction.followup.send(
+        view = CardSettingsView(color, DEFAULT_BACKGROUND, user_id)
+        if allow_ephemeral:
+            await send(
                 "Background image invalid; using default.",
                 file=discord.File(path),
                 view=view,
                 ephemeral=True,
             )
-        finally:
-            try:
-                os.remove(path)
-            except OSError:
-                pass
+        else:
+            await send(
+                "Background image invalid; using default.",
+                file=discord.File(path),
+                view=view,
+            )
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def setup(
+    tree,
+    user_stats,
+    user_card_settings,
+    save_data,
+    xp_needed,
+    DEFAULT_COLOR,
+    DEFAULT_BACKGROUND,
+    render_level_card,
+    CardSettingsView,
+    **__
+):
+    """Register the level command with the provided command tree."""
+
+    @tree.command(name="level", description="Show your level card")
+    async def level_command(interaction: discord.Interaction):
+        await interaction.response.defer()
+        await send_level_card(
+            interaction.user,
+            interaction.followup.send,
+            user_stats,
+            user_card_settings,
+            save_data,
+            xp_needed,
+            DEFAULT_COLOR,
+            DEFAULT_BACKGROUND,
+            render_level_card,
+            CardSettingsView,
+            allow_ephemeral=True,
+        )


### PR DESCRIPTION
## Summary
- allow `a.`/`A.` prefixed messages to show the level card
- refactor level card logic into reusable helper
- document the new prefix usage

## Testing
- `python -m py_compile bot.py command/level.py`


------
https://chatgpt.com/codex/tasks/task_e_6898a24ddbc88321a42933887b7ba9df