### PR TITLE
Ensure error alerts are ephemeral

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -159,7 +159,7 @@ def main() -> None:
             self.add_item(self.bg_input)
 
         async def on_submit(self, interaction: discord.Interaction) -> None:
-            await interaction.response.defer(thinking=True)
+            await interaction.response.defer(thinking=True, ephemeral=True)
 
             try:
                 parts = [int(p.strip()) for p in self.color_input.value.split(",")]

--- a/command/level.py
+++ b/command/level.py
@@ -70,19 +70,13 @@ async def send_level_card(
             outfile=f"level_{user_id}.png",
         )
         view = CardSettingsView(color, DEFAULT_BACKGROUND, user_id)
-        if allow_ephemeral:
-            await send(
-                f"{WARNING_EMOJI}Background image invalid; using default.",
-                file=discord.File(path),
-                view=view,
-                ephemeral=True,
-            )
-        else:
-            await send(
-                f"{WARNING_EMOJI}Background image invalid; using default.",
-                file=discord.File(path),
-                view=view,
-            )
+        kwargs = {"ephemeral": True} if allow_ephemeral else {}
+        await send(
+            f"{WARNING_EMOJI}Background image invalid; using default.",
+            file=discord.File(path),
+            view=view,
+            **kwargs,
+        )
     finally:
         try:
             os.remove(path)


### PR DESCRIPTION
## Summary
- ensure modal submissions defer with `ephemeral=True` to keep alerts private
- simplify level card error handling to send ephemeral alerts when supported

## Testing
- `python -m py_compile bot.py command/level.py`


------
https://chatgpt.com/codex/tasks/task_e_6898aeef6a0c832184b0974cf5d74aa8