### PR TITLE
Add wallet command with slash and prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
 The bot will respond to `!ping` messages with `Pong!`.
 
 The level card can also be requested with the `a.` or `A.` prefix. For example,
-you can type `a. level` or `A.level` to see your card.
+you can type `a.level` to see your card.
+
+You can view wallet balances with the `/wallet` slash command or by typing
+`a.wallet` (optionally mentioning another user).
 
 A slash command `/add-role` can give a role to a user, optionally for a
 limited time (`1h`, `1d`, `7w`, `1m`). Timed roles are stored so they persist

--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,7 @@ import urllib.parse
 import random
 from datetime import datetime, timezone
 from command.level import send_level_card
+from command.wallet import send_wallet
 
 DATA_FILE = "user_data.json"
 user_card_settings: dict[int, dict[str, Any]] = {}
@@ -282,7 +283,9 @@ def main() -> None:
         content = message.content.strip()
         lower = content.lower()
         if lower.startswith("a."):
-            cmd = lower[2:].lstrip()
+            remainder = message.content[2:].lstrip()
+            parts = remainder.split(maxsplit=1)
+            cmd = parts[0].lower() if parts else ""
             if cmd == "level":
                 await send_level_card(
                     message.author,
@@ -297,6 +300,10 @@ def main() -> None:
                     CardSettingsView,
                     allow_ephemeral=False,
                 )
+                return
+            if cmd == "wallet":
+                target = message.mentions[0] if message.mentions else message.author
+                await send_wallet(target, message.channel.send)
                 return
         if message.content == "!ping":
             await message.channel.send("Pong!")

--- a/command/wallet.py
+++ b/command/wallet.py
@@ -1,0 +1,68 @@
+import discord
+from discord import app_commands
+
+# Placeholder for a database call; returns mock wallet data.
+async def get_wallet(user_id: int) -> dict[str, int]:
+    return {"coin": 12850, "diamonds": 42, "deluxe": 7}
+
+
+def format_number(n: int) -> str:
+    return f"{n:,}"
+
+
+async def send_wallet(user: discord.abc.User, send) -> None:
+    """Fetch and send a wallet embed for ``user`` using ``send``."""
+    data = await get_wallet(user.id)
+    display = getattr(user, "display_name", None)
+    header = f"{user.name}'s Wallet" + (f" • aka {display}" if display and display != user.name else "")
+
+    embed = discord.Embed(colour=0xF1C40F)
+    embed.set_author(name=header, icon_url=user.display_avatar.with_size(128).url)
+    embed.set_thumbnail(url=user.display_avatar.with_size(256).url)
+    embed.add_field(
+        name="Coin",
+        value=f"[\u200b](https://i.ibb.co/LDbB8Db5/Coin.png) **{format_number(data['coin'])}**",
+        inline=True,
+    )
+    embed.add_field(
+        name="Diamonds",
+        value=f"[\u200b](https://i.ibb.co/R400ZFyT/Diamond.png) **{format_number(data['diamonds'])}**",
+        inline=True,
+    )
+    embed.add_field(
+        name="Deluxe Coin",
+        value=f"[\u200b](https://i.ibb.co/Q7LtJxXt/Deluxe-Coin.png) **{format_number(data['deluxe'])}**",
+        inline=True,
+    )
+    embed.set_footer(text=f"ID: {user.id}")
+
+    view = discord.ui.View()
+    view.add_item(
+        discord.ui.Button(
+            custom_id="wallet_earn", label="Earn", style=discord.ButtonStyle.success
+        )
+    )
+    view.add_item(
+        discord.ui.Button(
+            custom_id="wallet_shop", label="Shop", style=discord.ButtonStyle.primary
+        )
+    )
+    view.add_item(
+        discord.ui.Button(
+            custom_id="wallet_transfer", label="Transfer", style=discord.ButtonStyle.secondary
+        )
+    )
+
+    await send(embed=embed, view=view)
+
+
+def setup(tree, *_args, **_kwargs) -> None:
+    """Register the wallet slash command."""
+
+    @tree.command(name="wallet", description="Show a user's wallet")
+    @app_commands.describe(user="Whose wallet to view (default: you)")
+    async def wallet(interaction: discord.Interaction, user: discord.User | None = None) -> None:
+        await interaction.response.defer()
+        target = user or interaction.user
+        await send_wallet(target, interaction.followup.send)
+


### PR DESCRIPTION
## Summary
- add `/wallet` slash command and reusable wallet embed builder
- allow `a.wallet` prefix command
- document wallet command in README

## Testing
- `python -m py_compile bot.py command/wallet.py`


------
https://chatgpt.com/codex/tasks/task_e_68998fcb130c8321b05e00947d19fed1