### PR TITLE
Install dependencies on bot startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,11 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
 
 ## Setup
 
-1. Create a virtual environment and install dependencies:
+1. Create a virtual environment (optional):
 
    ```bash
    python -m venv venv
    source venv/bin/activate
-   pip install -r requirements.txt
    ```
 
 2. Create a `.env` file in the project root with your bot token:
@@ -18,7 +17,8 @@ This is a simple Discord bot written in Python using [`discord.py`](https://pypi
    BOT_TOKEN=your_bot_token_here
    ```
 
-3. Run the bot:
+3. Run the bot. It will automatically install the required dependencies on
+   first start:
 
    ```bash
    python bot.py

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,27 @@
 import os
 import json
+import sys
+import subprocess
 from io import BytesIO
 from typing import Any
 import importlib
 import asyncio
+
+
+def ensure_dependencies() -> None:
+    """Install required third-party packages if they're missing."""
+    try:
+        import discord  # noqa: F401
+        import dotenv  # noqa: F401
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-r", "requirements.txt"]
+        )
+
+
+ensure_dependencies()
+
 
 import discord
 from discord import app_commands


### PR DESCRIPTION
## Summary
- Install requirements automatically when the bot starts via new `ensure_dependencies`
- Update setup docs to note automatic dependency installation

## Testing
- `python -m py_compile bot.py`
- `python bot.py` *(fails: RuntimeError: BOT_TOKEN not set in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6899d3e2598c8321afd9d0883d9eedc3