### PR TITLE
Add badge slots and accent color for level UI

### DIFF
--- a/command/level.js
+++ b/command/level.js
@@ -48,6 +48,7 @@ async function sendLevelCard(user, send, { userStats, userCardSettings, saveData
 
   // Create the separator component
   const separator = new SeparatorBuilder().setDivider(true);
+  separator.data.accent_color = 0xffffff;
 
   // Create the button inside a container
   const button = new ButtonBuilder()
@@ -56,9 +57,11 @@ async function sendLevelCard(user, send, { userStats, userCardSettings, saveData
     .setEmoji('<:Botgear:1403611995814629447>')
     .setStyle(ButtonStyle.Secondary);
 
-  const container = new ContainerBuilder().addActionRowComponents(
-    new ActionRowBuilder().addComponents(button)
-  );
+  const container = new ContainerBuilder()
+    .setAccentColor(0xffffff)
+    .addActionRowComponents(
+      new ActionRowBuilder().addComponents(button)
+    );
 
   await send({
     files: [attachment],

--- a/levelCard.js
+++ b/levelCard.js
@@ -31,6 +31,24 @@ function glowCircle(ctx, cx, cy, r) {
   ctx.stroke();
 }
 
+function drawBadgeSlot(ctx, cx, cy, r) {
+  // subtle fill
+  const g = ctx.createRadialGradient(cx, cy, r * 0.1, cx, cy, r);
+  g.addColorStop(0, 'rgba(0,255,255,0.14)');
+  g.addColorStop(1, 'rgba(0,0,0,0)');
+  ctx.fillStyle = g;
+  ctx.beginPath();
+  ctx.arc(cx, cy, r, 0, Math.PI * 2);
+  ctx.fill();
+
+  // crisp ring
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = 'rgba(0,255,255,0.9)';
+  ctx.beginPath();
+  ctx.arc(cx, cy, r - 1.5, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
 function drawProgressBar(ctx, x, y, w, h, progress, label, starImg) {
   // Track
   ctx.globalAlpha = 0.9;
@@ -220,11 +238,19 @@ async function renderLevelCard({
   statCard('Prestige', prestige, leftPad);
   statCard('Total XP', totalXP, leftPad + 280);
 
-  // 3 circles on right
-  const circlesCenterY = rowTop + 35;
-  glowCircle(ctx, W - rightPad - 80,  circlesCenterY, 60);
-  glowCircle(ctx, W - rightPad - 150, circlesCenterY + 8, 48);
-  glowCircle(ctx, W - rightPad - 215, circlesCenterY - 6, 42);
+  // --- Badge slots (three separate circles, not overlapping)
+  const cy = rowTop + 35;
+  const badgeR = 42;      // circle radius
+  const badgeGap = 36;    // extra space between circles
+
+  // rightmost center; adjust the -10 padding if needed
+  const rightmostCx = W - rightPad - badgeR - 10;
+
+  // compute evenly spaced centers (left, middle, right)
+  const step = badgeR * 2 + badgeGap; // center-to-center distance
+  const centers = [rightmostCx - step * 2, rightmostCx - step, rightmostCx];
+
+  centers.forEach((cx) => drawBadgeSlot(ctx, cx, cy, badgeR));
 
   // ----- Progress bar (below everything)
   const barW = W - 72;


### PR DESCRIPTION
## Summary
- add drawBadgeSlot helper for badge placeholders
- evenly space badge slots instead of overlapping glow circles
- set white accent color for separator and container components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ad5533d588321988e0e3ecf73da8d