### PR TITLE
Hide empty progress bar and restructure level components

### DIFF
--- a/command/level.js
+++ b/command/level.js
@@ -40,11 +40,9 @@ async function sendLevelCard(user, send, { userStats, userCardSettings, saveData
   const attachment = new AttachmentBuilder(buffer, { name: `level_${user.id}.png` });
   
   // Create the media gallery component
-  const mediaGallery = new MediaGalleryBuilder()
-    .addItems(
-      new MediaGalleryItemBuilder()
-        .setURL(`attachment://level_${user.id}.png`)
-    );
+  const mediaGallery = new MediaGalleryBuilder().addItems(
+    new MediaGalleryItemBuilder().setURL(`attachment://level_${user.id}.png`)
+  );
 
   // Create the separator component
   const separator = new SeparatorBuilder().setDivider(true);
@@ -59,13 +57,13 @@ async function sendLevelCard(user, send, { userStats, userCardSettings, saveData
 
   const container = new ContainerBuilder()
     .setAccentColor(0xffffff)
-    .addActionRowComponents(
-      new ActionRowBuilder().addComponents(button)
-    );
+    .addMediaGalleryComponents(mediaGallery)
+    .addSeparatorComponents(separator)
+    .addActionRowComponents(new ActionRowBuilder().addComponents(button));
 
   await send({
     files: [attachment],
-    components: [mediaGallery, separator, container],
+    components: [container],
     flags: MessageFlags.IsComponentsV2
   });
 }

--- a/levelCard.js
+++ b/levelCard.js
@@ -63,8 +63,23 @@ function drawProgressBar(ctx, x, y, w, h, progress, label, starImg) {
   grad.addColorStop(0, 'rgba(0,255,255,1)');
   grad.addColorStop(1, 'rgba(0,170,255,1)');
   ctx.fillStyle = grad;
-  roundRect(ctx, x, y, fillW, h, h / 2);
-  ctx.fill();
+
+  if (progress >= 1) {
+    // full progress retains rounded corners
+    roundRect(ctx, x, y, fillW, h, h / 2);
+    ctx.fill();
+  } else {
+    // left side rounded, right side square
+    const r = h / 2;
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x, y, x, y + h, r);
+    ctx.arcTo(x, y + h, x + r, y + h, r);
+    ctx.lineTo(x + fillW, y + h);
+    ctx.lineTo(x + fillW, y);
+    ctx.closePath();
+    ctx.fill();
+  }
 
   // Star icon
   let textLeft = x + 18;
@@ -258,8 +273,10 @@ async function renderLevelCard({
   const barX = 36;
   const barY = rowTop + 70 + 28;
 
-  const progress = Math.max(0, Math.min(1, currentXP / nextLevelXP));
-  drawProgressBar(ctx, barX, barY, barW, barH, progress, `${currentXP} / ${nextLevelXP}`, starImg);
+  if (currentXP > 0) {
+    const progress = Math.max(0, Math.min(1, currentXP / nextLevelXP));
+    drawProgressBar(ctx, barX, barY, barW, barH, progress, `${currentXP} / ${nextLevelXP}`, starImg);
+  }
 
   return canvas.toBuffer('image/png');
 }


### PR DESCRIPTION
## Summary
- Skip rendering the progress bar when a user has 0 XP
- Draw progress bar fills without rounded end caps
- Wrap media gallery and separator inside a container component for the level command

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad74140748321823437cb4d053ad1