### PR TITLE
feat: rework wallet command and add coin rewards

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -62,6 +62,13 @@ async function addXp(user, amount, client) {
   saveData();
 }
 
+function addCoins(user, amount) {
+  const stats = userStats[user.id] || { level:1, xp:0, total_xp:0, coins:0, diamonds:0, deluxe_coins:0 };
+  stats.coins = (stats.coins || 0) + amount;
+  userStats[user.id] = stats;
+  saveData();
+}
+
 function scheduleRole(userId, guildId, roleId, expiresAt, save=false) {
   const entry = { user_id:userId, guild_id:guildId, role_id:roleId, expires_at:expiresAt };
   if (save) {
@@ -98,6 +105,7 @@ client.once('ready', () => {
 client.on('messageCreate', async message => {
   if (message.author.bot) return;
   await addXp(message.author, Math.floor(Math.random()*10)+1, client);
+  addCoins(message.author, Math.floor(Math.random()*100)+1);
   if (message.content === '!ping') {
     message.channel.send({
       components: [new TextDisplayBuilder().setContent('Pong!')],

--- a/command/wallet.js
+++ b/command/wallet.js
@@ -1,39 +1,51 @@
-const { SlashCommandBuilder, AttachmentBuilder, MessageFlags, MediaGalleryBuilder, MediaGalleryItemBuilder } = require('discord.js');
-const { createCanvas, loadImage } = require('canvas');
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  ContainerBuilder,
+  SectionBuilder,
+  ThumbnailBuilder,
+  SeparatorBuilder,
+  TextDisplayBuilder,
+} = require('discord.js');
 
-async function renderWalletCard(user, stats) {
-  const width = 400, height = 200;
-  const canvas = createCanvas(width, height);
-  const ctx = canvas.getContext('2d');
-  ctx.fillStyle = '#23272a';
-  ctx.fillRect(0,0,width,height);
-  ctx.fillStyle = '#fff';
-  ctx.font = '20px sans-serif';
-  ctx.fillText(user.username, 20, 40);
-  ctx.fillText(`Coins: ${stats.coins||0}`, 20, 80);
-  ctx.fillText(`Diamonds: ${stats.diamonds||0}`, 20, 110);
-  ctx.fillText(`Deluxe: ${stats.deluxe_coins||0}`, 20, 140);
-  return canvas.toBuffer('image/png');
-}
+async function sendWallet(user, send, { userStats }) {
+  const stats = userStats[user.id] || { coins: 0, diamonds: 0, deluxe_coins: 0 };
+  const coins = stats.coins || 0;
+  const diamonds = stats.diamonds || 0;
+  const deluxe = stats.deluxe_coins || 0;
+  const inventoryValue = 0;
+  const totalValue = coins + diamonds + deluxe + inventoryValue;
 
-async function sendWalletCard(user, send, { userStats }) {
-  const stats = userStats[user.id] || { coins:0, diamonds:0, deluxe_coins:0 };
-  const buffer = await renderWalletCard(user, stats);
-  const attachment = new AttachmentBuilder(buffer, { name: `wallet_${user.id}.png` });
-  const media = new MediaGalleryBuilder().addItems(
-    new MediaGalleryItemBuilder().setURL(`attachment://wallet_${user.id}.png`),
+  const headerSection = new SectionBuilder()
+    .setThumbnailAccessory(new ThumbnailBuilder().setURL(user.displayAvatarURL()))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `## ${user.username}'s Wallet\n<:stars:1404723253200552009> Total Value: ${totalValue}\n# <:reply:1403665761825980456>Inventory Value: ${inventoryValue}`,
+      ),
+    );
+
+  const balancesText = new TextDisplayBuilder().setContent(
+    `> <:Coin:1404348210146967612> Coin: ${coins}\n\n> <:Diamond:1404350385463885886> Diamond: ${diamonds}\n\n> <:DeluxeCoin:1404351654005833799> Deluxe Coin: ${deluxe}`,
   );
-  await send({ files:[attachment], components:[media] });
+
+  const container = new ContainerBuilder()
+    .setAccentColor(0xffffff)
+    .addSectionComponents(headerSection)
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addTextDisplayComponents(balancesText);
+
+  await send({ components: [container], flags: MessageFlags.IsComponentsV2 });
 }
 
 function setup(client, resources) {
-  const command = new SlashCommandBuilder().setName('wallet').setDescription('Show your wallet card');
+  const command = new SlashCommandBuilder().setName('wallet').setDescription('Show your wallet');
   client.application.commands.create(command);
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'wallet') return;
     await interaction.deferReply({ flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2 });
-    await sendWalletCard(interaction.user, interaction.editReply.bind(interaction), resources);
+    await sendWallet(interaction.user, interaction.editReply.bind(interaction), resources);
   });
 }
 
 module.exports = { setup };
+


### PR DESCRIPTION
## Summary
- replace wallet embed with Discord Components v2 container message
- award users 1-100 coins for each message sent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aebe9615083219d3a3a671697fd0d