### PR TITLE
Make /wallet command response public

### DIFF
--- a/command/wallet.js
+++ b/command/wallet.js
@@ -42,7 +42,7 @@ function setup(client, resources) {
   client.application.commands.create(command);
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'wallet') return;
-    await interaction.deferReply({ flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2 });
+    await interaction.deferReply({ flags: MessageFlags.IsComponentsV2 });
     await sendWallet(interaction.user, interaction.editReply.bind(interaction), resources);
   });
 }


### PR DESCRIPTION
## Summary
- remove ephemeral flag from wallet command so responses are visible to everyone

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689af0dbee94832190e31724338f5ebd