### PR TITLE
Fix shop component bug and remove legacy level-button command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -99,7 +99,7 @@ const client = new Client({
   intents:[GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildVoiceStates]
 });
 
-  client.once('ready', () => {
+  client.once('ready', async () => {
     console.log(`Logged in as ${client.user.tag}`);
     addRoleCommand.setup(client, resources);
     levelCommand.setup(client, resources);
@@ -107,6 +107,17 @@ const client = new Client({
     inventoryCommand.setup(client, resources);
     shopCommand.setup(client, resources);
     timedRoles.forEach(r => scheduleRole(r.user_id, r.guild_id, r.role_id, r.expires_at));
+
+    // Remove deprecated /level-button command if it exists
+    try {
+      const commands = await client.application.commands.fetch();
+      const legacy = commands.find(cmd => cmd.name === 'level-button');
+      if (legacy) {
+        await client.application.commands.delete(legacy.id);
+      }
+    } catch (err) {
+      console.warn('Failed to remove legacy /level-button command', err);
+    }
   });
 
 client.on('messageCreate', async message => {

--- a/command/shop.js
+++ b/command/shop.js
@@ -2,7 +2,6 @@ const {
   SlashCommandBuilder,
   MessageFlags,
   ContainerBuilder,
-  SectionBuilder,
   SeparatorBuilder,
   TextDisplayBuilder,
   ActionRowBuilder,
@@ -26,18 +25,16 @@ async function sendShop(user, send, resources, state = { page: 1, type: 'coin' }
   const start = (page - 1) * perPage;
   const pageItems = items.slice(start, start + perPage);
 
-  const itemSections = [];
+  const itemDisplays = [];
   for (let i = 0; i < perPage; i++) {
     const item = pageItems[i];
     const name = item ? item.name : '???';
     const price = item ? item.price : '???';
     const note = item ? item.note : '';
     const emoji = item ? item.emoji : '❓';
-    itemSections.push(
-      new SectionBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(
-          `**${emoji} ${name}**\n-# Price: ${price}\n> ${note}`,
-        ),
+    itemDisplays.push(
+      new TextDisplayBuilder().setContent(
+        `**${emoji} ${name}**\n-# Price: ${price}\n> ${note}`,
       ),
     );
   }
@@ -81,7 +78,7 @@ async function sendShop(user, send, resources, state = { page: 1, type: 'coin' }
       new TextDisplayBuilder().setContent(`* Page ${page}/${pages}`),
     )
     .addSeparatorComponents(new SeparatorBuilder())
-    .addSectionComponents(...itemSections)
+    .addTextDisplayComponents(...itemDisplays)
     .addSeparatorComponents(new SeparatorBuilder())
     .addActionRowComponents(
       new ActionRowBuilder().addComponents(pageSelect),


### PR DESCRIPTION
## Summary
- replace item section components with text displays to satisfy builder validation
- drop deprecated /level-button command on startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3e2a48688321bb20b12de3ab435c