### PR TITLE
Add padlock item, usage, and robbery mechanics

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -7,6 +7,8 @@ const walletCommand = require('./command/wallet');
 const addRoleCommand = require('./command/addRole');
 const inventoryCommand = require('./command/inventory');
 const shopCommand = require('./command/shop');
+const useItemCommand = require('./command/useItem');
+const robCommand = require('./command/rob');
 
 const DATA_FILE = 'user_data.json';
 let userStats = {};
@@ -106,6 +108,8 @@ const client = new Client({
     walletCommand.setup(client, resources);
     inventoryCommand.setup(client, resources);
     shopCommand.setup(client, resources);
+    useItemCommand.setup(client, resources);
+    robCommand.setup(client, resources);
     timedRoles.forEach(r => scheduleRole(r.user_id, r.guild_id, r.role_id, r.expires_at));
 
     // Remove deprecated /level-button command if it exists
@@ -146,6 +150,31 @@ client.on('messageCreate', async message => {
         message.channel.send.bind(message.channel),
         resources
       );
+    } else if (lowerAfter.startsWith('use item')) {
+      const args = afterPrefix.split(/\s+/).slice(2);
+      const itemId = args[0];
+      const amount = parseInt(args[1], 10) || 1;
+      await useItemCommand.handleUseItem(
+        message.author,
+        itemId,
+        amount,
+        message.channel.send.bind(message.channel),
+        resources,
+      );
+    } else if (lowerAfter.startsWith('rob')) {
+      const target = message.mentions.users.first();
+      if (target) {
+        await robCommand.executeRob(
+          message.author,
+          target,
+          message.channel.send.bind(message.channel),
+          resources,
+        );
+      } else {
+        await message.channel.send({
+          content: '<:warning:1404101025849147432> Please mention a user to rob.',
+        });
+      }
     } else if (lowerAfter.startsWith('add role')) {
       const args = afterPrefix.split(/\s+/).slice(2);
       await addRoleCommand.handleTextCommand(message, args, resources);

--- a/command/rob.js
+++ b/command/rob.js
@@ -1,0 +1,165 @@
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  ContainerBuilder,
+  SectionBuilder,
+  TextDisplayBuilder,
+  ThumbnailBuilder,
+  SeparatorBuilder,
+} = require('discord.js');
+
+const WARNING = '<:warning:1404101025849147432>';
+const COIN_EMOJI = '<:Coin:1404348210146967612>';
+
+const FAIL_MESSAGES = [
+  "{usermention} tried to rob {robbinguser} but got caught by the police.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# police-caught",
+  "{usermention} was recorded on CCTV while targeting {robbinguser}.\nYou paid {amount} coin to {robbinguser} for compensation.\n-# cctv-proof",
+  "{usermention} set off a security alarm during the attempt on {robbinguser}.\nYou paid {amount} coin to {robbinguser} for damages.\n-# alarm-triggered",
+  "{usermention} was detained by a security guard while reaching for {robbinguser}.\nYou paid {amount} coin to {robbinguser} as a settlement.\n-# security-detained",
+  "{usermention} was identified by witnesses after trying to rob {robbinguser}.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# witness-report",
+  "{usermention} got flagged by an anti-theft tracker linked to {robbinguser}.\nYou paid {amount} coin to {robbinguser} as a penalty.\n-# tracker-flagged",
+  "{usermention} signed a confession after failing to rob {robbinguser}.\nYou paid {amount} coin to {robbinguser} as part of the agreement.\n-# confession-deal",
+  "{usermention} tried to snatch from {robbinguser} and broke their strap.\nYou paid {amount} coin to {robbinguser} for repairs.\n-# property-damage",
+  "{usermention} was stopped by neighborhood watch while targeting {robbinguser}.\nYou paid {amount} coin to {robbinguser} as compensation.\n-# neighborhood-watch",
+  "{usermention} failed the pickpocket—{robbinguser} filed a report.\nYou paid {amount} coin to {robbinguser} to settle it.\n-# report-filed",
+  "{usermention} triggered a dye pack during the attempt on {robbinguser}.\nYou paid {amount} coin to {robbinguser} for cleaning and damages.\n-# dye-pack",
+  "{usermention} lost a quick arbitration after trying to rob {robbinguser}.\nYou paid {amount} coin to {robbinguser} per the ruling.\n-# arbitration",
+  "{usermention} faced a civil claim from {robbinguser} after the failed robbery.\nYou paid {amount} coin to {robbinguser} as a settlement.\n-# civil-claim",
+  "{usermention} got caught and agreed to make amends to {robbinguser}.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# make-amends",
+  "{usermention} attempted to rob {robbinguser} but was tracked by their phone.\nYou paid {amount} coin to {robbinguser} as compensation.\n-# device-tracked",
+  "{usermention} was stopped by staff, and {robbinguser} pressed charges.\nYou paid {amount} coin to {robbinguser} to drop the charges.\n-# dropped-charges",
+  "{usermention} tried to rob {robbinguser} and caused a scene.\nYou paid {amount} coin to {robbinguser} for inconvenience.\n-# disturbance",
+  "{usermention} failed the grab; {robbinguser}'s insurance denied the claim.\nYou paid {amount} coin to {robbinguser} to cover the deductible.\n-# insurance-deductible",
+  "{usermention} was caught on bodycam during the attempt on {robbinguser}.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# bodycam",
+  "{usermention} faced a court order after trying to rob {robbinguser}.\nYou paid {amount} coin to {robbinguser} by order of the court.\n-# court-order",
+  "{usermention} was intercepted by bystanders while targeting {robbinguser}.\nYou paid {amount} coin to {robbinguser} as compensation.\n-# bystander-stop",
+  "{usermention} attempted a grab and damaged {robbinguser}'s phone case.\nYou paid {amount} coin to {robbinguser} for replacement costs.\n-# replace-costs",
+  "{usermention} got flagged by the bank’s fraud system while targeting {robbinguser}.\nYou paid {amount} coin to {robbinguser} as a chargeback penalty.\n-# bank-penalty",
+  "{usermention} failed to rob {robbinguser} and accepted a plea deal.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# plea-deal",
+];
+
+const PADLOCK_FAIL_MESSAGES = [
+  "{usermention} tried to rob {robbinguser}, but their wallet is padlocked.\nYou paid {amount} coin to {robbinguser} for tampering with a locked wallet.\n-# padlock",
+  "{usermention} tugged at {robbinguser}'s padlocked wallet and set off the lock alarm.\nYou paid {amount} coin to {robbinguser} as a security fee.\n-# lock-alarm",
+  "{usermention} couldn’t get past {robbinguser}'s padlock.\nYou paid {amount} coin to {robbinguser} for attempted theft.\n-# access-denied",
+  "{usermention} tried the zipper—padlock says no.\nYou paid {amount} coin to {robbinguser} for the trouble.\n-# locked-tight",
+  "{usermention} picked at {robbinguser}'s padlock and got flagged by the anti-tamper latch.\nYou paid {amount} coin to {robbinguser} as a penalty.\n-# anti-tamper",
+  "{usermention} failed to rob {robbinguser}; the padlock recorded the attempt.\nYou paid {amount} coin to {robbinguser} as restitution.\n-# attempt-logged",
+  "{usermention} pulled on {robbinguser}'s wallet, but the padlock held.\nYou paid {amount} coin to {robbinguser} for damages to the strap.\n-# strap-damage",
+  "{usermention} tried to crack {robbinguser}'s lock and triggered a security ping.\nYou paid {amount} coin to {robbinguser} as a lock breach fee.\n-# lock-breach",
+  "{usermention} couldn’t open {robbinguser}'s padlock; the key never turned.\nYou paid {amount} coin to {robbinguser} for attempting to steal.\n-# key-denied",
+  "{usermention} messed with {robbinguser}'s padlock and left scratches.\nYou paid {amount} coin to {robbinguser} for repair costs.\n-# repair-costs",
+  "{usermention} tried to bypass {robbinguser}'s padlock, but it auto-notified.\nYou paid {amount} coin to {robbinguser} per the lock policy.\n-# auto-notify",
+  "{usermention} rattled {robbinguser}'s padlocked wallet and got noticed.\nYou paid {amount} coin to {robbinguser} for disturbing the peace.\n-# noticed",
+  "{usermention} attempted to open {robbinguser}'s wallet; padlock engaged a loud click.\nYou paid {amount} coin to {robbinguser} as compensation.\n-# loud-click",
+  "{usermention} tried to force {robbinguser}'s padlock but failed.\nYou paid {amount} coin to {robbinguser} for the failed break-in.\n-# forced-fail",
+  "{usermention} thought the padlock was decorative on {robbinguser}'s wallet—it's not.\nYou paid {amount} coin to {robbinguser} as a fine.\n-# not-decorative",
+  "{usermention} attempted a quick snatch, but {robbinguser}'s padlock held firm.\nYou paid {amount} coin to {robbinguser} for the attempt.\n-# held-firm",
+];
+
+function weightedPercent() {
+  let r = Math.random() * 5050;
+  for (let p = 1; p <= 100; p++) {
+    r -= 101 - p;
+    if (r <= 0) return p;
+  }
+  return 1;
+}
+
+function buildEmbed(color, title, desc, thumb) {
+  const section = new SectionBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(`### ${title}`),
+    new TextDisplayBuilder().setContent(desc),
+  );
+  if (thumb) section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumb));
+  return new ContainerBuilder()
+    .setAccentColor(color)
+    .addSectionComponents(section);
+}
+
+async function executeRob(robber, target, send, resources) {
+  if (robber.id === target.id) {
+    await send({ content: `${WARNING} You cannot rob yourself.`, ephemeral: true });
+    return;
+  }
+  const robberStats = resources.userStats[robber.id] || { coins: 0 };
+  const targetStats = resources.userStats[target.id] || { coins: 0 };
+  const now = Date.now();
+  const targetProtected = targetStats.padlock_until && targetStats.padlock_until > now;
+
+  const fail = targetProtected || Math.random() < 0.75;
+  if (fail) {
+    const percent = weightedPercent();
+    let amount = Math.floor((robberStats.coins || 0) * percent / 100);
+    if (amount < 1) amount = 1;
+    if ((robberStats.coins || 0) < amount) amount = robberStats.coins || 0;
+    robberStats.coins = (robberStats.coins || 0) - amount;
+    targetStats.coins = (targetStats.coins || 0) + amount;
+    resources.userStats[robber.id] = robberStats;
+    resources.userStats[target.id] = targetStats;
+    resources.saveData();
+    const arr = targetProtected ? PADLOCK_FAIL_MESSAGES : FAIL_MESSAGES;
+    const msg = arr[Math.floor(Math.random() * arr.length)]
+      .replace(/\{usermention\}/g, robber.toString())
+      .replace(/\{robbinguser\}/g, target.toString())
+      .replace(/\{amount\}/g, amount);
+    await send({
+      components: [buildEmbed(0xff0000, `Failed robbing ${target.username}`, msg)],
+      flags: MessageFlags.IsComponentsV2,
+      ephemeral: true,
+    });
+    const alert = buildEmbed(0xffffff, 'Robbing Alert!', `Hey ${target}, ${robber} was trying to rob your wallet but failed`);
+    try {
+      await target.send({ components: [alert], flags: MessageFlags.IsComponentsV2 });
+    } catch {}
+    return;
+  }
+
+  const percent = weightedPercent();
+  let amount = Math.floor((targetStats.coins || 0) * percent / 100);
+  if (amount < 1) amount = 1;
+  if ((targetStats.coins || 0) < amount) amount = targetStats.coins || 0;
+  targetStats.coins = (targetStats.coins || 0) - amount;
+  robberStats.coins = (robberStats.coins || 0) + amount;
+  resources.userStats[robber.id] = robberStats;
+  resources.userStats[target.id] = targetStats;
+  resources.saveData();
+
+  await send({
+    components: [
+      buildEmbed(
+        0x00ff00,
+        `You have robbed ${target.username}`,
+        `You have successfully robbed ${target}, you earned ${amount} ${COIN_EMOJI}`,
+        'https://i.ibb.co/q3mZ8N8T/ef097dbe-8f94-48b2-9a39-e7c8d4cc420b.png',
+      ),
+    ],
+    flags: MessageFlags.IsComponentsV2,
+    ephemeral: true,
+  });
+  const alert = buildEmbed(
+    0xff0000,
+    'You got Robbed!',
+    `Hey ${target}, ${robber} has successfully robbed your wallet and stole ${amount} ${COIN_EMOJI}`,
+    'https://i.ibb.co/q3mZ8N8T/ef097dbe-8f94-48b2-9a39-e7c8d4cc420b.png',
+  );
+  try {
+    await target.send({ components: [alert], flags: MessageFlags.IsComponentsV2 });
+  } catch {}
+}
+
+function setup(client, resources) {
+  const command = new SlashCommandBuilder()
+    .setName('rob')
+    .setDescription('Rob someone')
+    .addUserOption(opt => opt.setName('user').setDescription('Target user').setRequired(true));
+  client.application.commands.create(command);
+
+  client.on('interactionCreate', async interaction => {
+    if (!interaction.isChatInputCommand() || interaction.commandName !== 'rob') return;
+    const target = interaction.options.getUser('user');
+    await executeRob(interaction.user, target, interaction.reply.bind(interaction), resources);
+  });
+}
+
+module.exports = { setup, executeRob };

--- a/command/shop.js
+++ b/command/shop.js
@@ -16,10 +16,11 @@ const {
 } = require('discord.js');
 const { renderShopMedia } = require('../shopMedia');
 const { renderDeluxeMedia } = require('../shopMediaDeluxe');
+const { ITEMS } = require('../items');
 
 // Currently coin and deluxe shops with no items
 const SHOP_ITEMS = {
-  coin: [],
+  coin: [ITEMS.padlock],
   deluxe: [],
 };
 
@@ -154,6 +155,11 @@ function setup(client, resources) {
         return;
       }
       stats.coins -= item.price;
+      stats.inventory = stats.inventory || [];
+      const base = ITEMS[item.id] || item;
+      const existing = stats.inventory.find(i => i.id === item.id);
+      if (existing) existing.amount = (existing.amount || 0) + 1;
+      else stats.inventory.push({ ...base, amount: 1 });
       resources.userStats[interaction.user.id] = stats;
       resources.saveData();
       await interaction.reply({

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -1,0 +1,134 @@
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  ContainerBuilder,
+  SectionBuilder,
+  ThumbnailBuilder,
+  SeparatorBuilder,
+  TextDisplayBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
+const { ITEMS } = require('../items');
+
+const WARNING = '<:warning:1404101025849147432>';
+
+function padlockEmbed(user) {
+  return new ContainerBuilder()
+    .setAccentColor(0x00ff00)
+    .addSectionComponents(
+      new SectionBuilder()
+        .setThumbnailAccessory(
+          new ThumbnailBuilder().setURL(ITEMS.padlock.image),
+        )
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent('### WALLET LOCKET'),
+          new TextDisplayBuilder().setContent(
+            `Hey ${user}, you have used **×1 Padlock ${ITEMS.padlock.emoji}**, your wallet will be temporary protected from being robbed!`,
+          ),
+        ),
+    )
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent('Padlock last 24h'));
+}
+
+function expiredPadlockContainer(user, disable = false) {
+  const btn = new ButtonBuilder()
+    .setCustomId('padlock-use-again')
+    .setStyle(ButtonStyle.Success)
+    .setLabel('Use ×1 Padlock')
+    .setEmoji(ITEMS.padlock.emoji);
+  if (disable) btn.setDisabled(true);
+  return new ContainerBuilder()
+    .setAccentColor(0xff0000)
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `### Padlock broke\n* ${user}, your **Padlock ${ITEMS.padlock.emoji}** is broken after 24h. Your wallet is no longer protected.`,
+      ),
+    )
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addActionRowComponents(new ActionRowBuilder().addComponents(btn));
+}
+
+function schedulePadlock(user, expiresAt, resources) {
+  const delay = expiresAt - Date.now();
+  setTimeout(async () => {
+    const stats = resources.userStats[user.id];
+    if (stats) {
+      stats.padlock_until = 0;
+      resources.saveData();
+    }
+    try {
+      await user.send({ components: [expiredPadlockContainer(user)], flags: MessageFlags.IsComponentsV2 });
+    } catch {}
+  }, Math.max(delay, 0));
+}
+
+function usePadlock(user, resources) {
+  const stats = resources.userStats[user.id] || { inventory: [] };
+  stats.inventory = stats.inventory || [];
+  const entry = stats.inventory.find(i => i.id === 'padlock');
+  if (!entry || entry.amount < 1) {
+    return { error: `${WARNING} You need at least 1 Padlock to use.` };
+  }
+  if (stats.padlock_until && stats.padlock_until > Date.now()) {
+    return { error: `${WARNING} Padlock is already active.` };
+  }
+  entry.amount -= 1;
+  if (entry.amount <= 0) stats.inventory = stats.inventory.filter(i => i !== entry);
+  const expires = Date.now() + 24 * 60 * 60 * 1000;
+  stats.padlock_until = expires;
+  resources.userStats[user.id] = stats;
+  resources.saveData();
+  schedulePadlock(user, expires, resources);
+  return { component: padlockEmbed(user) };
+}
+
+async function handleUseItem(user, itemId, amount, send, resources) {
+  let result;
+  if (itemId === 'padlock') {
+    result = usePadlock(user, resources);
+  } else {
+    result = { error: `${WARNING} Cannot use this item.` };
+  }
+  if (result.error) {
+    await send({ content: result.error, ephemeral: true });
+  } else {
+    await send({ components: [result.component], flags: MessageFlags.IsComponentsV2, ephemeral: true });
+  }
+}
+
+function setup(client, resources) {
+  const usable = Object.values(ITEMS).filter(i => i.useable);
+  const command = new SlashCommandBuilder()
+    .setName('use-item')
+    .setDescription('Use an item')
+    .addStringOption(opt => {
+      opt.setName('item').setDescription('Item ID').setRequired(true);
+      usable.forEach(i => opt.addChoices({ name: i.name, value: i.id }));
+      return opt;
+    })
+    .addIntegerOption(opt => opt.setName('amount').setDescription('Amount').setMinValue(1));
+  client.application.commands.create(command);
+
+  client.on('interactionCreate', async interaction => {
+    if (!interaction.isChatInputCommand() || interaction.commandName !== 'use-item') return;
+    const itemId = interaction.options.getString('item');
+    const amount = interaction.options.getInteger('amount') || 1;
+    await handleUseItem(interaction.user, itemId, amount, interaction.reply.bind(interaction), resources);
+  });
+
+  client.on('interactionCreate', async interaction => {
+    if (!interaction.isButton() || interaction.customId !== 'padlock-use-again') return;
+    const res = usePadlock(interaction.user, resources);
+    if (res.error) {
+      await interaction.reply({ content: res.error, ephemeral: true });
+    } else {
+      await interaction.update({ components: [expiredPadlockContainer(interaction.user, true)], flags: MessageFlags.IsComponentsV2 });
+      await interaction.followUp({ components: [res.component], flags: MessageFlags.IsComponentsV2, ephemeral: true });
+    }
+  });
+}
+
+module.exports = { setup, handleUseItem };

--- a/command/wallet.js
+++ b/command/wallet.js
@@ -6,6 +6,9 @@ const {
   ThumbnailBuilder,
   SeparatorBuilder,
   TextDisplayBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
 } = require('discord.js');
 
 async function sendWallet(user, send, { userStats }) {
@@ -28,11 +31,20 @@ async function sendWallet(user, send, { userStats }) {
     `> <:Coin:1404348210146967612> Coin: ${coins}\n> <:Diamond:1404350385463885886> Diamond: ${diamonds}\n> <:DeluxeCoin:1404351654005833799> Deluxe Coin: ${deluxe}`,
   );
 
+  const padlockActive = stats.padlock_until && stats.padlock_until > Date.now();
+  const padlockButton = new ButtonBuilder()
+    .setLabel('')
+    .setEmoji(padlockActive ? '<:ITPadlock:1405440520678932480>' : '<:SBline:1405444056200253521>')
+    .setStyle(padlockActive ? ButtonStyle.Success : ButtonStyle.Secondary)
+    .setDisabled(true);
+
   const container = new ContainerBuilder()
     .setAccentColor(0xffffff)
     .addSectionComponents(headerSection)
     .addSeparatorComponents(new SeparatorBuilder())
-    .addTextDisplayComponents(balancesText);
+    .addTextDisplayComponents(balancesText)
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addActionRowComponents(new ActionRowBuilder().addComponents(padlockButton));
 
   await send({ components: [container], flags: MessageFlags.IsComponentsV2 });
 }

--- a/items.js
+++ b/items.js
@@ -1,0 +1,16 @@
+const ITEMS = {
+  padlock: {
+    id: 'padlock',
+    name: 'Padlock',
+    emoji: '<:ITPadlock:1405440520678932480>',
+    rarity: 'Common',
+    value: 500,
+    useable: true,
+    type: 'Accessory',
+    note: '',
+    image: 'https://i.ibb.co/zVykckz3/Padlock.png',
+    price: 35000,
+  },
+};
+
+module.exports = { ITEMS };


### PR DESCRIPTION
## Summary
- Add reusable Padlock item, shop entry, and wallet indicator
- Implement /use-item command with padlock protection and expiry alert
- Introduce /rob command with weighted rewards and padlock-aware failure messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d8c99c7a08321a4ffcf8342b2dee5