### PR TITLE
Increase Discord client listener limit

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -100,6 +100,7 @@ const resources = { userStats, userCardSettings, saveData, xpNeeded, defaultColo
 const client = new Client({
   intents:[GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildVoiceStates]
 });
+client.setMaxListeners(20);
 
   client.once('ready', async () => {
     console.log(`Logged in as ${client.user.tag}`);


### PR DESCRIPTION
## Summary
- increase client event listener limit to avoid MaxListeners warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d93e90a8083219c9d90555c2a56ef