### PR TITLE
Enlarge coin display in shop and fix wallet padlock error

### DIFF
--- a/command/wallet.js
+++ b/command/wallet.js
@@ -33,7 +33,6 @@ async function sendWallet(user, send, { userStats }) {
 
   const padlockActive = stats.padlock_until && stats.padlock_until > Date.now();
   const padlockButton = new ButtonBuilder()
-    .setLabel('')
     .setEmoji(padlockActive ? '<:ITPadlock:1405440520678932480>' : '<:SBline:1405444056200253521>')
     .setStyle(padlockActive ? ButtonStyle.Success : ButtonStyle.Secondary)
     .setDisabled(true);

--- a/shopMedia.js
+++ b/shopMedia.js
@@ -181,7 +181,7 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
 
   // --- BOTTOM: price only (no buy button) ---
   const rowY = y + h - 20;
-  const coinSize = 22;
+  const coinSize = 30;
   const coinX = x + pad;
   const coinY = rowY - coinSize - 2;
 
@@ -190,7 +190,7 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
   }
 
   ctx.fillStyle = '#ffffff';
-  ctx.font = 'bold 20px Sans';
+  ctx.font = 'bold 26px Sans';
   ctx.fillText(String(item.price ?? '???'), coinX + coinSize + 8, coinY + coinSize - 2);
 }
 

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -293,12 +293,12 @@ async function deluxeCard(ctx, x, y, w, h, item = {}) {
   // price + button row
   const rowY = gy + gh - 18;
   const coinX = gx + pad + 16;
-  const coinY = rowY - 28;
-  coinGold(ctx, coinX, coinY, 13);
+  const coinY = rowY - 33;
+  coinGold(ctx, coinX, coinY, 18);
 
   ctx.fillStyle = '#ffffff';
-  ctx.font = 'bold 20px Sans';
-  ctx.fillText(String(item.price ?? '???'), coinX + 22, coinY + 7);
+  ctx.font = 'bold 24px Sans';
+  ctx.fillText(String(item.price ?? '???'), coinX + 26, coinY + 12);
 
   // button (gold foil)
   const btnW = 132, btnH = 40;


### PR DESCRIPTION
## Summary
- Make coin currency more prominent by increasing coin icon and price font sizes in shop media rendering
- Prevent wallet command crash by removing empty label from padlock button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689daae84a248321b93ee9bfd642d0e2