### PR TITLE
Make prefix warnings ephemeral

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -198,7 +198,10 @@ client.on('messageCreate', async message => {
         ),
       );
     }
-    await message.channel.send({ components: [container], flags: MessageFlags.IsComponentsV2 });
+    await message.channel.send({
+      components: [container],
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+    });
     await message.delete().catch(() => {});
     return;
   }
@@ -258,6 +261,7 @@ client.on('messageCreate', async message => {
       } else {
         await message.channel.send({
           content: '<:SBWarning:1404101025849147432> Please provide a user ID to rob.',
+          flags: MessageFlags.Ephemeral,
         });
       }
     } else if (lowerAfter.startsWith('add role')) {
@@ -288,7 +292,10 @@ client.on('messageCreate', async message => {
           ),
         );
       }
-      await message.channel.send({ components: [container], flags: MessageFlags.IsComponentsV2 });
+      await message.channel.send({
+        components: [container],
+        flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+      });
       return;
     }
     message.channel.send({

--- a/command/addRole.js
+++ b/command/addRole.js
@@ -61,7 +61,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
           `${WARN}Usage: a. add role [userID] [roleID] [time]`,
         ),
       ],
-      flags: MessageFlags.IsComponentsV2,
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
     });
     return;
   }
@@ -73,7 +73,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   if (!member || !role) {
     await message.channel.send({
       components: [new TextDisplayBuilder().setContent(`${WARN}Invalid user or role ID.`)],
-      flags: MessageFlags.IsComponentsV2,
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
     });
     return;
   }
@@ -87,7 +87,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   } catch {
     await message.channel.send({
       components: [new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`)],
-      flags: MessageFlags.IsComponentsV2,
+      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
     });
     return;
   }
@@ -97,7 +97,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
     if (!seconds) {
       await message.channel.send({
         components: [new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`)],
-        flags: MessageFlags.IsComponentsV2,
+        flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
       });
       return;
     }

--- a/command/rob.js
+++ b/command/rob.js
@@ -106,7 +106,11 @@ function buildEmbed(color, title, desc, thumb) {
 
 async function executeRob(robber, target, send, resources) {
   if (robber.id === target.id) {
-    await send({ content: `${WARNING} You cannot rob yourself.`, ephemeral: true });
+    await send({
+      content: `${WARNING} You cannot rob yourself.`,
+      ephemeral: true,
+      flags: MessageFlags.Ephemeral,
+    });
     return;
   }
   const robberStats = resources.userStats[robber.id] || { coins: 0 };
@@ -117,6 +121,7 @@ async function executeRob(robber, target, send, resources) {
     await send({
       content: `${WARNING} You need at least ${formatNumber(MIN_COINS)} ${COIN_EMOJI} to rob someone.`,
       ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -124,6 +129,7 @@ async function executeRob(robber, target, send, resources) {
     await send({
       content: `${WARNING} ${target.username} must have at least ${formatNumber(MIN_COINS)} ${COIN_EMOJI} to be robbed.`,
       ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -133,6 +139,7 @@ async function executeRob(robber, target, send, resources) {
     await send({
       content: `${WARNING} You can rob again <t:${timestamp}:R>.`,
       ephemeral: true,
+      flags: MessageFlags.Ephemeral,
     });
     return;
   }

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -93,7 +93,7 @@ async function handleUseItem(user, itemId, amount, send, resources) {
     result = { error: `${WARNING} Cannot use this item.` };
   }
   if (result.error) {
-    await send({ content: result.error, ephemeral: true });
+    await send({ content: result.error, ephemeral: true, flags: MessageFlags.Ephemeral });
   } else {
     await send({ components: [result.component], flags: MessageFlags.IsComponentsV2 });
   }


### PR DESCRIPTION
## Summary
- use ephemeral flags for pending request warnings
- ensure rob, add-role, and use-item prefix errors are ephemeral

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e11e759b4832198d50b6eb62c89be