### PR TITLE
Expand shop currency display and public responses

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -141,10 +141,10 @@ client.setMaxListeners(20);
               ),
             );
           }
-          await interaction.reply({
-            components: [container],
-            flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-          });
+            await interaction.reply({
+              components: [container],
+              flags: MessageFlags.IsComponentsV2,
+            });
           return;
         }
       }
@@ -198,13 +198,13 @@ client.on('messageCreate', async message => {
         ),
       );
     }
-    await message.channel.send({
-      components: [container],
-      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
-    });
-    await message.delete().catch(() => {});
-    return;
-  }
+      await message.channel.send({
+        components: [container],
+        flags: MessageFlags.IsComponentsV2,
+      });
+      await message.delete().catch(() => {});
+      return;
+    }
   if (content.toLowerCase().startsWith('a.')) {
     const afterPrefix = content.slice(2).trim();
     const lowerAfter = afterPrefix.toLowerCase();
@@ -259,10 +259,9 @@ client.on('messageCreate', async message => {
           resources,
         );
       } else {
-        await message.channel.send({
-          content: '<:SBWarning:1404101025849147432> Please provide a user ID to rob.',
-          flags: MessageFlags.Ephemeral,
-        });
+          await message.channel.send({
+            content: '<:SBWarning:1404101025849147432> Please provide a user ID to rob.',
+          });
       }
     } else if (lowerAfter.startsWith('add role')) {
       const args = afterPrefix.split(/\s+/).slice(2);
@@ -294,7 +293,7 @@ client.on('messageCreate', async message => {
       }
       await message.channel.send({
         components: [container],
-        flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }

--- a/command/addCurrency.js
+++ b/command/addCurrency.js
@@ -37,11 +37,11 @@ function setup(client, resources) {
     const amountStr = interaction.options.getString('amount');
     const amount = parseAmount(amountStr);
     if (isNaN(amount)) {
-      await interaction.reply({ content: `${WARNING} Invalid amount.`, ephemeral: true });
+      await interaction.reply({ content: `${WARNING} Invalid amount.` });
       return;
     }
     if (type === 'deluxe' && !DELUXE_ALLOWED.has(interaction.user.id)) {
-      await interaction.reply({ content: `${WARNING} You cannot modify Deluxe Coin.`, ephemeral: true });
+      await interaction.reply({ content: `${WARNING} You cannot modify Deluxe Coin.` });
       return;
     }
     const stats = resources.userStats[target.id] || { coins: 0, diamonds: 0, deluxe_coins: 0 };

--- a/command/addItem.js
+++ b/command/addItem.js
@@ -30,12 +30,12 @@ function setup(client, resources) {
     const itemId = interaction.options.getString('item');
     const amount = interaction.options.getInteger('amount');
     if (!Number.isInteger(amount) || amount === 0) {
-      await interaction.reply({ content: `${WARNING} Invalid amount.`, ephemeral: true });
+      await interaction.reply({ content: `${WARNING} Invalid amount.` });
       return;
     }
     const base = ITEMS[itemId];
     if (!base) {
-      await interaction.reply({ content: `${WARNING} Invalid item.`, ephemeral: true });
+      await interaction.reply({ content: `${WARNING} Invalid item.` });
       return;
     }
     const stats = resources.userStats[target.id] || { inventory: [] };
@@ -43,7 +43,7 @@ function setup(client, resources) {
     const entry = stats.inventory.find(i => i.id === itemId);
     if (amount < 0) {
       if (!entry) {
-        await interaction.reply({ content: `${WARNING} User does not have this item.`, ephemeral: true });
+        await interaction.reply({ content: `${WARNING} User does not have this item.` });
         return;
       }
       entry.amount = (entry.amount || 0) + amount;

--- a/command/addRole.js
+++ b/command/addRole.js
@@ -43,7 +43,7 @@ function setup(client, { scheduleRole }) {
       if (!seconds) {
         await interaction.followUp({
           components: [new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`)],
-          flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+          flags: MessageFlags.IsComponentsV2,
         });
         return;
       }
@@ -61,7 +61,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
           `${WARN}Usage: a. add role [userID] [roleID] [time]`,
         ),
       ],
-      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+      flags: MessageFlags.IsComponentsV2,
     });
     return;
   }
@@ -73,7 +73,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   if (!member || !role) {
     await message.channel.send({
       components: [new TextDisplayBuilder().setContent(`${WARN}Invalid user or role ID.`)],
-      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+      flags: MessageFlags.IsComponentsV2,
     });
     return;
   }
@@ -87,7 +87,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   } catch {
     await message.channel.send({
       components: [new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`)],
-      flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+      flags: MessageFlags.IsComponentsV2,
     });
     return;
   }
@@ -97,7 +97,7 @@ async function handleTextCommand(message, args, { scheduleRole }) {
     if (!seconds) {
       await message.channel.send({
         components: [new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`)],
-        flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }

--- a/command/level.js
+++ b/command/level.js
@@ -118,7 +118,7 @@ function setup(client, resources) {
     if (colorParts.length !== 3 || colorParts.some(n => isNaN(n) || n < 0 || n > 255)) {
       await interaction.reply({
         components: [new TextDisplayBuilder().setContent(`${WARN}Invalid color.`)],
-        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }
@@ -129,7 +129,7 @@ function setup(client, resources) {
     } catch {
       await interaction.reply({
         components: [new TextDisplayBuilder().setContent(`${WARN}Invalid background URL.`)],
-        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }
@@ -139,7 +139,7 @@ function setup(client, resources) {
     if (!changed) {
       await interaction.reply({
         components: [new TextDisplayBuilder().setContent(`${WARN}No changes made.`)],
-        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }

--- a/command/rob.js
+++ b/command/rob.js
@@ -108,8 +108,6 @@ async function executeRob(robber, target, send, resources) {
   if (robber.id === target.id) {
     await send({
       content: `${WARNING} You cannot rob yourself.`,
-      ephemeral: true,
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -120,16 +118,12 @@ async function executeRob(robber, target, send, resources) {
   if ((robberStats.coins || 0) < MIN_COINS) {
     await send({
       content: `${WARNING} You need at least ${formatNumber(MIN_COINS)} ${COIN_EMOJI} to rob someone.`,
-      ephemeral: true,
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }
   if ((targetStats.coins || 0) < MIN_COINS) {
     await send({
       content: `${WARNING} ${target.username} must have at least ${formatNumber(MIN_COINS)} ${COIN_EMOJI} to be robbed.`,
-      ephemeral: true,
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }
@@ -138,8 +132,6 @@ async function executeRob(robber, target, send, resources) {
     const timestamp = Math.round(robberStats.rob_cooldown_until / 1000);
     await send({
       content: `${WARNING} You can rob again <t:${timestamp}:R>.`,
-      ephemeral: true,
-      flags: MessageFlags.Ephemeral,
     });
     return;
   }

--- a/command/shop.js
+++ b/command/shop.js
@@ -148,11 +148,11 @@ function setup(client, resources) {
         const index = parseInt(interaction.customId.split('-')[2], 10);
         const items = SHOP_ITEMS[state.type] || [];
         const start = (state.page - 1) * 6;
-        const item = items[start + index];
-        if (!item) {
-          await interaction.reply({ content: 'Item not available.', ephemeral: true });
-          return;
-        }
+          const item = items[start + index];
+          if (!item) {
+            await interaction.reply({ content: 'Item not available.' });
+            return;
+          }
         const modal = new ModalBuilder()
           .setCustomId(`shop-buy-modal-${interaction.message.id}-${index}`)
           .setTitle('Buy Item');
@@ -227,46 +227,46 @@ function setup(client, resources) {
       const messageId = parts[3];
       const index = parseInt(parts[4], 10);
       const state = shopStates.get(messageId);
-      if (!state || interaction.user.id !== state.userId) {
-        await interaction.reply({
-          components: [new TextDisplayBuilder().setContent('Purchase expired.')],
-          flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-        });
-        return;
-      }
+        if (!state || interaction.user.id !== state.userId) {
+          await interaction.reply({
+            components: [new TextDisplayBuilder().setContent('Purchase expired.')],
+            flags: MessageFlags.IsComponentsV2,
+          });
+          return;
+        }
       const items = SHOP_ITEMS[state.type] || [];
       const start = (state.page - 1) * 6;
       const item = items[start + index];
-      if (!item) {
-        await interaction.reply({
-          components: [new TextDisplayBuilder().setContent('Item not available.')],
-          flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-        });
-        return;
-      }
+        if (!item) {
+          await interaction.reply({
+            components: [new TextDisplayBuilder().setContent('Item not available.')],
+            flags: MessageFlags.IsComponentsV2,
+          });
+          return;
+        }
       const amount = parseInt(interaction.fields.getTextInputValue('amount'), 10);
-      if (isNaN(amount) || amount <= 0) {
-        await interaction.reply({
-          components: [new TextDisplayBuilder().setContent('Invalid amount.')],
-          flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-        });
-        return;
-      }
+        if (isNaN(amount) || amount <= 0) {
+          await interaction.reply({
+            components: [new TextDisplayBuilder().setContent('Invalid amount.')],
+            flags: MessageFlags.IsComponentsV2,
+          });
+          return;
+        }
       const stats = resources.userStats[interaction.user.id] || { coins: 0 };
       const total = item.price * amount;
       const coinEmoji = '<:CRCoin:1405595571141480570>';
-      if ((stats.coins || 0) < total) {
-        const need = total - (stats.coins || 0);
-        await interaction.reply({
-          components: [
-            new TextDisplayBuilder().setContent(
-              `You don't have enough coins. You need ${need} ${coinEmoji} more to purchase.`,
-            ),
-          ],
-          flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-        });
-        return;
-      }
+        if ((stats.coins || 0) < total) {
+          const need = total - (stats.coins || 0);
+          await interaction.reply({
+            components: [
+              new TextDisplayBuilder().setContent(
+                `You don't have enough coins. You need ${need} ${coinEmoji} more to purchase.`,
+              ),
+            ],
+            flags: MessageFlags.IsComponentsV2,
+          });
+          return;
+        }
       const buyBtn = new ButtonBuilder()
         .setCustomId(`shop-confirm-${item.id}-${amount}`)
         .setLabel('Buy')
@@ -285,10 +285,10 @@ function setup(client, resources) {
         )
         .addSeparatorComponents(new SeparatorBuilder())
         .addActionRowComponents(new ActionRowBuilder().addComponents(buyBtn, cancelBtn));
-      const reply = await interaction.reply({
-        components: [container],
-        flags: MessageFlags.Ephemeral | MessageFlags.IsComponentsV2,
-      });
+        const reply = await interaction.reply({
+          components: [container],
+          flags: MessageFlags.IsComponentsV2,
+        });
       const timer = setTimeout(async () => {
         const current = resources.pendingRequests.get(interaction.user.id);
         if (current && current.timer === timer) {

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -68,7 +68,7 @@ function schedulePadlock(user, expiresAt, resources) {
 function usePadlock(user, resources) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   stats.inventory = stats.inventory || [];
-  const entry = stats.inventory.find(i => i.id === 'padlock');
+  const entry = stats.inventory.find(i => i.id === 'Padlock');
   if (!entry || entry.amount < 1) {
     return { error: `${WARNING} You need at least 1 Padlock to use.` };
   }
@@ -87,13 +87,13 @@ function usePadlock(user, resources) {
 
 async function handleUseItem(user, itemId, amount, send, resources) {
   let result;
-  if (itemId === 'padlock') {
+  if (itemId === 'Padlock') {
     result = usePadlock(user, resources);
   } else {
     result = { error: `${WARNING} Cannot use this item.` };
   }
   if (result.error) {
-    await send({ content: result.error, ephemeral: true, flags: MessageFlags.Ephemeral });
+    await send({ content: result.error });
   } else {
     await send({ components: [result.component], flags: MessageFlags.IsComponentsV2 });
   }
@@ -123,7 +123,7 @@ function setup(client, resources) {
     if (!interaction.isButton() || interaction.customId !== 'padlock-use-again') return;
     const res = usePadlock(interaction.user, resources);
     if (res.error) {
-      await interaction.reply({ content: res.error, ephemeral: true });
+      await interaction.reply({ content: res.error });
     } else {
       await interaction.update({ components: [expiredPadlockContainer(interaction.user, true)], flags: MessageFlags.IsComponentsV2 });
       await interaction.followUp({ components: [res.component], flags: MessageFlags.IsComponentsV2 });

--- a/command/wallet.js
+++ b/command/wallet.js
@@ -17,7 +17,11 @@ async function sendWallet(user, send, { userStats }) {
   const coins = stats.coins || 0;
   const diamonds = stats.diamonds || 0;
   const deluxe = stats.deluxe_coins || 0;
-  const inventoryValue = 0;
+  const inventory = stats.inventory || [];
+  const inventoryValue = inventory.reduce(
+    (sum, item) => sum + (item.value || 0) * (item.amount || 0),
+    0,
+  );
   const totalValue = coins + diamonds + deluxe + inventoryValue;
 
   const headerSection = new SectionBuilder()

--- a/items.js
+++ b/items.js
@@ -1,6 +1,6 @@
 const ITEMS = {
   padlock: {
-    id: 'padlock',
+    id: 'Padlock',
     name: 'Padlock',
     emoji: '<:ITPadlock:1405440520678932480>',
     rarity: 'Common',

--- a/shopMedia.js
+++ b/shopMedia.js
@@ -181,7 +181,7 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
 
   // --- BOTTOM: price only (no buy button) ---
   const rowY = y + h - 20;
-  const coinSize = 30;
+  const coinSize = 36;
   const coinX = x + pad;
   const coinY = rowY - coinSize - 2;
 
@@ -190,7 +190,7 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
   }
 
   ctx.fillStyle = '#ffffff';
-  ctx.font = 'bold 26px Sans';
+  ctx.font = 'bold 36px Sans';
   ctx.fillText(String(item.price ?? '???'), coinX + coinSize + 8, coinY + coinSize - 2);
 }
 

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -291,14 +291,15 @@ async function deluxeCard(ctx, x, y, w, h, item = {}) {
   ctx.stroke();
 
   // price + button row
-  const rowY = gy + gh - 18;
-  const coinX = gx + pad + 16;
-  const coinY = rowY - 33;
-  coinGold(ctx, coinX, coinY, 18);
+    const rowY = gy + gh - 18;
+    const coinX = gx + pad + 16;
+    const coinR = 24;
+    const coinY = rowY - coinR - 15;
+    coinGold(ctx, coinX, coinY, coinR);
 
-  ctx.fillStyle = '#ffffff';
-  ctx.font = 'bold 24px Sans';
-  ctx.fillText(String(item.price ?? '???'), coinX + 26, coinY + 12);
+    ctx.fillStyle = '#ffffff';
+    ctx.font = 'bold 32px Sans';
+    ctx.fillText(String(item.price ?? '???'), coinX + coinR + 8, coinY + coinR - 6);
 
   // button (gold foil)
   const btnW = 132, btnH = 40;


### PR DESCRIPTION
## Summary
- Enlarge coin graphics and price text in shop UIs
- Count inventory item value in wallet balance
- Make responses public and update Padlock item ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689eda3c5ef883219356871265517c8f