### PR TITLE
Restrict item and currency commands to specific role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # Copy this file to .env and replace with your actual token
 BOT_TOKEN=your_bot_token_here
+ADMIN_ROLE_ID=your_admin_role_id_here

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This is a simple Discord bot rewritten in JavaScript using [`discord.js`](https:
    npm install
    ```
 
-2. Create a `.env` file with your bot token:
+2. Create a `.env` file with your bot token and the role ID allowed to use admin commands:
 
    ```env
    BOT_TOKEN=your_bot_token_here
+   ADMIN_ROLE_ID=role_id_allowed_to_manage_currency_and_items
    ```
 
 3. Run the bot:

--- a/command/addCurrency.js
+++ b/command/addCurrency.js
@@ -3,6 +3,7 @@ const { formatNumber, parseAmount } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
 const DELUXE_ALLOWED = new Set(['1152200741566566440', '902736357766594611']);
+const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID;
 
 function setup(client, resources) {
   const command = new SlashCommandBuilder()
@@ -32,6 +33,10 @@ function setup(client, resources) {
 
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'add-currency') return;
+    if (!interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
+      await interaction.reply({ content: `${WARNING} You do not have permission to use this command.` });
+      return;
+    }
     const target = interaction.options.getUser('user');
     const type = interaction.options.getString('type');
     const amountStr = interaction.options.getString('amount');

--- a/command/addItem.js
+++ b/command/addItem.js
@@ -3,6 +3,7 @@ const { ITEMS } = require('../items');
 const { formatNumber } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
+const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID;
 
 function setup(client, resources) {
   const command = new SlashCommandBuilder()
@@ -26,6 +27,10 @@ function setup(client, resources) {
 
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'add-item') return;
+    if (!interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
+      await interaction.reply({ content: `${WARNING} You do not have permission to use this command.` });
+      return;
+    }
     const target = interaction.options.getUser('user');
     const itemId = interaction.options.getString('item');
     const amount = interaction.options.getInteger('amount');


### PR DESCRIPTION
## Summary
- Limit `/add-item` and `/add-currency` commands to users with the role specified by `ADMIN_ROLE_ID`
- Document new `ADMIN_ROLE_ID` env var and update setup instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ef0c021888321ac786b1e7a5a7a3f