### PR TITLE
Rename padlock item ID to Padlock

### DIFF
--- a/command/shop.js
+++ b/command/shop.js
@@ -23,7 +23,7 @@ const { ITEMS } = require('../items');
 
 // Currently coin and deluxe shops with no items
 const SHOP_ITEMS = {
-  coin: [ITEMS.padlock],
+  coin: [ITEMS.Padlock],
   deluxe: [],
 };
 

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -20,12 +20,12 @@ function padlockEmbed(user) {
     .addSectionComponents(
       new SectionBuilder()
         .setThumbnailAccessory(
-          new ThumbnailBuilder().setURL(ITEMS.padlock.image),
+          new ThumbnailBuilder().setURL(ITEMS.Padlock.image),
         )
         .addTextDisplayComponents(
           new TextDisplayBuilder().setContent('### WALLET LOCKET'),
           new TextDisplayBuilder().setContent(
-            `Hey ${user}, you have used **×1 Padlock ${ITEMS.padlock.emoji}**, your wallet will be temporary protected from being robbed!`,
+            `Hey ${user}, you have used **×1 Padlock ${ITEMS.Padlock.emoji}**, your wallet will be temporary protected from being robbed!`,
           ),
         ),
     )
@@ -38,13 +38,13 @@ function expiredPadlockContainer(user, disable = false) {
     .setCustomId('padlock-use-again')
     .setStyle(ButtonStyle.Success)
     .setLabel('Use ×1 Padlock')
-    .setEmoji(ITEMS.padlock.emoji);
+    .setEmoji(ITEMS.Padlock.emoji);
   if (disable) btn.setDisabled(true);
   return new ContainerBuilder()
     .setAccentColor(0xff0000)
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        `### Padlock broke\n* ${user}, your **Padlock ${ITEMS.padlock.emoji}** is broken after 24h. Your wallet is no longer protected.`,
+        `### Padlock broke\n* ${user}, your **Padlock ${ITEMS.Padlock.emoji}** is broken after 24h. Your wallet is no longer protected.`,
       ),
     )
     .addSeparatorComponents(new SeparatorBuilder())

--- a/items.js
+++ b/items.js
@@ -1,5 +1,5 @@
 const ITEMS = {
-  padlock: {
+  Padlock: {
     id: 'Padlock',
     name: 'Padlock',
     emoji: '<:ITPadlock:1405440520678932480>',


### PR DESCRIPTION
## Summary
- Rename padlock item key to `Padlock`
- Update item references in shop and use-item commands
- Run item ID update script for user data

## Testing
- `node updateItemIds.js`
- `npm test` *(fails: process did not complete in reasonable time due to scanning node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a030d22e2c8321becd4b11ef07f957