### PR TITLE
fix: normalize inventory and padlock expiry

### DIFF
--- a/command/addItem.js
+++ b/command/addItem.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('discord.js');
 const { ITEMS } = require('../items');
-const { formatNumber } = require('../utils');
+const { formatNumber, normalizeInventory } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
 const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID;
@@ -45,6 +45,7 @@ function setup(client, resources) {
     }
     const stats = resources.userStats[target.id] || { inventory: [] };
     stats.inventory = stats.inventory || [];
+    normalizeInventory(stats);
     const entry = stats.inventory.find(i => i.id === itemId);
     if (amount < 0) {
       if (!entry) {
@@ -59,6 +60,7 @@ function setup(client, resources) {
       if (entry) entry.amount = (entry.amount || 0) + amount;
       else stats.inventory.push({ ...base, amount });
     }
+    normalizeInventory(stats);
     resources.userStats[target.id] = stats;
     resources.saveData();
     const newEntry = stats.inventory.find(i => i.id === itemId);

--- a/command/inventory.js
+++ b/command/inventory.js
@@ -9,12 +9,16 @@ const {
   ActionRowBuilder,
   StringSelectMenuBuilder,
 } = require('discord.js');
+const { normalizeInventory } = require('../utils');
 
 const ITEM_TYPES = ['Consumable', 'Material', 'Misc', 'Tool', 'Accessory', 'Upgrade', 'Weapon', 'Chest', 'All'];
 const inventoryStates = new Map();
 
-async function sendInventory(user, send, { userStats }, state = { page: 1, types: ['All'] }) {
+async function sendInventory(user, send, { userStats, saveData }, state = { page: 1, types: ['All'] }) {
   const stats = userStats[user.id] || { inventory: [] };
+  normalizeInventory(stats);
+  userStats[user.id] = stats;
+  if (saveData) saveData();
   const items = stats.inventory || [];
   const totalValue = items.reduce((sum, item) => sum + (item.value || 0) * (item.amount || 0), 0);
   const types = state.types.includes('All') ? ['All'] : state.types;

--- a/command/shop.js
+++ b/command/shop.js
@@ -20,6 +20,7 @@ const {
 const { renderShopMedia } = require('../shopMedia');
 const { renderDeluxeMedia } = require('../shopMediaDeluxe');
 const { ITEMS } = require('../items');
+const { normalizeInventory } = require('../utils');
 
 // Currently coin and deluxe shops with no items
 const SHOP_ITEMS = {
@@ -181,6 +182,7 @@ function setup(client, resources) {
           return;
         }
         const stats = resources.userStats[interaction.user.id] || { coins: 0 };
+        normalizeInventory(stats);
         const total = item.price * amount;
         if ((stats.coins || 0) < total) {
           const need = total - (stats.coins || 0);
@@ -199,6 +201,7 @@ function setup(client, resources) {
         const existing = stats.inventory.find(i => i.id === item.id);
         if (existing) existing.amount = (existing.amount || 0) + amount;
         else stats.inventory.push({ ...base, amount });
+        normalizeInventory(stats);
         resources.userStats[interaction.user.id] = stats;
         resources.saveData();
         const pending = resources.pendingRequests.get(interaction.user.id);

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -11,6 +11,7 @@ const {
   ButtonStyle,
 } = require('discord.js');
 const { ITEMS } = require('../items');
+const { normalizeInventory } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
 
@@ -77,7 +78,7 @@ function schedulePadlock(user, expiresAt, resources) {
   const delay = expiresAt - Date.now();
   setTimeout(async () => {
     const stats = resources.userStats[user.id];
-    if (stats) {
+    if (stats && stats.padlock_until === expiresAt) {
       stats.padlock_until = 0;
       resources.saveData();
     }
@@ -101,6 +102,7 @@ function scheduleLandmine(user, expiresAt, resources) {
 function usePadlock(user, resources) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   stats.inventory = stats.inventory || [];
+  normalizeInventory(stats);
   const entry = stats.inventory.find(i => i.id === 'Padlock');
   if (!entry || entry.amount < 1) {
     return { error: `${WARNING} You need at least 1 Padlock to use.` };
@@ -110,6 +112,7 @@ function usePadlock(user, resources) {
   }
   entry.amount -= 1;
   if (entry.amount <= 0) stats.inventory = stats.inventory.filter(i => i !== entry);
+  normalizeInventory(stats);
   const expires = Date.now() + 24 * 60 * 60 * 1000;
   stats.padlock_until = expires;
   resources.userStats[user.id] = stats;
@@ -121,6 +124,7 @@ function usePadlock(user, resources) {
 function useLandmine(user, resources) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   stats.inventory = stats.inventory || [];
+  normalizeInventory(stats);
   const entry = stats.inventory.find(i => i.id === 'Landmine');
   if (!entry || entry.amount < 1) {
     return { error: `${WARNING} You need at least 1 Landmine to use.` };
@@ -131,6 +135,7 @@ function useLandmine(user, resources) {
   entry.amount -= 1;
   const remaining = entry.amount;
   if (entry.amount <= 0) stats.inventory = stats.inventory.filter(i => i !== entry);
+  normalizeInventory(stats);
   const expires = Date.now() + 24 * 60 * 60 * 1000;
   stats.landmine_until = expires;
   resources.userStats[user.id] = stats;

--- a/command/wallet.js
+++ b/command/wallet.js
@@ -10,11 +10,14 @@ const {
   ButtonBuilder,
   ButtonStyle,
 } = require('discord.js');
-const { formatNumber } = require('../utils');
+const { formatNumber, normalizeInventory } = require('../utils');
 const { ITEMS } = require('../items');
 
-async function sendWallet(user, send, { userStats }) {
+async function sendWallet(user, send, { userStats, saveData }) {
   const stats = userStats[user.id] || { coins: 0, diamonds: 0, deluxe_coins: 0 };
+  normalizeInventory(stats);
+  userStats[user.id] = stats;
+  if (saveData) saveData();
   const coins = stats.coins || 0;
   const diamonds = stats.diamonds || 0;
   const deluxe = stats.deluxe_coins || 0;

--- a/death.js
+++ b/death.js
@@ -8,6 +8,7 @@ const {
   MessageFlags,
 } = require('discord.js');
 const { ITEMS } = require('./items');
+const { normalizeInventory } = require('./utils');
 
 const RARITY_ORDER = [
   ['Common', 0.5],
@@ -22,6 +23,7 @@ const RARITY_ORDER = [
 async function handleDeath(user, action, resources) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   stats.inventory = stats.inventory || [];
+  normalizeInventory(stats);
 
   // Totem check
   const totem = stats.inventory.find(i => i.id === 'TotemOfUndying');
@@ -30,6 +32,7 @@ async function handleDeath(user, action, resources) {
     if (totem.amount <= 0) {
       stats.inventory = stats.inventory.filter(i => i !== totem);
     }
+    normalizeInventory(stats);
     resources.userStats[user.id] = stats;
     resources.saveData();
     const btn = new ButtonBuilder()
@@ -72,6 +75,7 @@ async function handleDeath(user, action, resources) {
     }
   }
 
+  normalizeInventory(stats);
   resources.userStats[user.id] = stats;
   resources.saveData();
 

--- a/utils.js
+++ b/utils.js
@@ -51,4 +51,20 @@ function parseAmount(str) {
   return Math.floor(value);
 }
 
-module.exports = { formatNumber, parseAmount };
+function normalizeInventory(stats) {
+  if (!stats || !Array.isArray(stats.inventory)) {
+    stats.inventory = [];
+    return;
+  }
+  const map = {};
+  for (const item of stats.inventory) {
+    if (!item || !item.id) continue;
+    const id = item.id;
+    const amount = item.amount || 0;
+    if (!map[id]) map[id] = { ...item, amount };
+    else map[id].amount += amount;
+  }
+  stats.inventory = Object.values(map).filter(i => (i.amount || 0) > 0);
+}
+
+module.exports = { formatNumber, parseAmount, normalizeInventory };


### PR DESCRIPTION
## Summary
- ensure padlock expiry resets only when appropriate and notify user
- add inventory normalizer to merge duplicates and drop zero amounts
- clean inventories when using, viewing, and updating items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a04e70811883219d4b8e5b1f44ca22