### PR TITLE
Allow specific user as admin and add padlock cleanup script

### DIFF
--- a/adminUsers.js
+++ b/adminUsers.js
@@ -1,0 +1,3 @@
+module.exports = new Set([
+  '902736357766594611'
+]);

--- a/command/addCurrency.js
+++ b/command/addCurrency.js
@@ -3,6 +3,7 @@ const { formatNumber, parseAmount } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
 const DELUXE_ALLOWED = new Set(['1152200741566566440', '902736357766594611']);
+const ADMIN_USERS = require('../adminUsers');
 const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID;
 
 function setup(client, resources) {
@@ -33,7 +34,7 @@ function setup(client, resources) {
 
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'add-currency') return;
-    if (!interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
+    if (!ADMIN_USERS.has(interaction.user.id) && !interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
       await interaction.reply({ content: `${WARNING} You do not have permission to use this command.` });
       return;
     }

--- a/command/addItem.js
+++ b/command/addItem.js
@@ -3,6 +3,7 @@ const { ITEMS } = require('../items');
 const { formatNumber, normalizeInventory } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
+const ADMIN_USERS = require('../adminUsers');
 const ADMIN_ROLE_ID = process.env.ADMIN_ROLE_ID;
 
 function setup(client, resources) {
@@ -27,7 +28,7 @@ function setup(client, resources) {
 
   client.on('interactionCreate', async interaction => {
     if (!interaction.isChatInputCommand() || interaction.commandName !== 'add-item') return;
-    if (!interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
+    if (!ADMIN_USERS.has(interaction.user.id) && !interaction.member.roles.cache.has(ADMIN_ROLE_ID)) {
       await interaction.reply({ content: `${WARNING} You do not have permission to use this command.` });
       return;
     }

--- a/removePadlock.js
+++ b/removePadlock.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, 'user_data.json');
+
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+} catch (err) {
+  console.error('Failed to read user data file:', err.message);
+  process.exit(1);
+}
+
+const userStats = data.user_stats || {};
+let removed = 0;
+
+for (const stats of Object.values(userStats)) {
+  if (!Array.isArray(stats.inventory)) continue;
+  const kept = [];
+  for (const item of stats.inventory) {
+    if (item.id === 'padlock') {
+      removed += item.amount || 1;
+    } else {
+      kept.push(item);
+    }
+  }
+  stats.inventory = kept;
+}
+
+if (removed > 0) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+  console.log(`Removed ${removed} padlock item(s).`);
+} else {
+  console.log('No padlock items found.');
+}


### PR DESCRIPTION
## Summary
- Permit user `902736357766594611` to run admin-only commands
- Provide `removePadlock.js` utility to purge `padlock` items from all inventories

## Testing
- `node removePadlock.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0534f46e083218c2b03f057819cbd