### PR TITLE
Reduce rob fail penalty

### DIFF
--- a/command/rob.js
+++ b/command/rob.js
@@ -147,7 +147,7 @@ async function executeRob(robber, target, send, resources) {
 
   const fail = targetProtected || Math.random() < 0.65;
   if (fail) {
-    const percent = weightedPercent(10, 50);
+    const percent = weightedPercent(5, 15);
     let amount = Math.floor((robberStats.coins || 0) * percent / 100);
     if (amount < 1) amount = 1;
     if ((robberStats.coins || 0) < amount) amount = robberStats.coins || 0;


### PR DESCRIPTION
## Summary
- Reduce penalty on failed robberies to 5%-15% of robber's wallet

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1b1205a8483219aa18ef81fb16d38