### PR TITLE
Preserve plot selection in farm view

### DIFF
--- a/command/farmView.js
+++ b/command/farmView.js
@@ -124,7 +124,11 @@ function buildFarmContainer(user, selected = [], farm = {}) {
     .setMinValues(0)
     .setMaxValues(9)
     .addOptions(
-      Array.from({ length: 9 }, (_, i) => ({ label: `${i + 1}`, value: `${i + 1}` }))
+      Array.from({ length: 9 }, (_, i) => ({
+        label: `${i + 1}`,
+        value: `${i + 1}`,
+        default: selected.includes(i + 1),
+      }))
     );
 
   const harvestable = Object.values(farm).some(plot => {


### PR DESCRIPTION
## Summary
- Keep previously selected farm plots highlighted in the selection menu so it doesn't reset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a72aeab1288321991b2f16c581be17