### PR TITLE
Fix wheat seed emoji in farm select

### DIFF
--- a/command/farmView.js
+++ b/command/farmView.js
@@ -8,6 +8,7 @@ const {
   MediaGalleryItemBuilder,
   ActionRowBuilder,
   StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
   AttachmentBuilder,
   ButtonBuilder,
   ButtonStyle,
@@ -261,16 +262,12 @@ function setup(client, resources) {
         .setCustomId(`farm-plant-select:${interaction.message.id}`)
         .setPlaceholder('Seed')
         .addOptions(
-          seeds.map(s => {
-            const match = /<(a?):(\w+):(\d+)>/.exec(s.emoji);
-            return {
-              label: `${s.name} - ${s.amount}`,
-              value: s.id,
-              emoji: match
-                ? { id: match[3], name: match[2], animated: Boolean(match[1]) }
-                : undefined,
-            };
-          }),
+          seeds.map(s =>
+            new StringSelectMenuOptionBuilder()
+              .setLabel(`${s.name} - ${s.amount}`)
+              .setValue(s.id)
+              .setEmoji(s.emoji),
+          ),
         );
       const container = new ContainerBuilder()
         .setAccentColor(0xffffff)


### PR DESCRIPTION
## Summary
- use StringSelectMenuOptionBuilder to supply seed emojis like <:ITWheatseed:1408147889657483305>
- simplify seed selection option construction

## Testing
- `node --check command/farmView.js`
- `npm test` *(fails: command terminated because it scans all node_modules and did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a768abc2a483218d94bfa2adfccbab