### PR TITLE
Fix invalid emoji in farm seed select menu

### DIFF
--- a/command/farmView.js
+++ b/command/farmView.js
@@ -12,7 +12,6 @@ const {
   AttachmentBuilder,
   ButtonBuilder,
   ButtonStyle,
-  parseEmoji,
 } = require('discord.js');
 const { createCanvas, loadImage } = require('canvas');
 const { ITEMS } = require('../items');
@@ -267,9 +266,8 @@ function setup(client, resources) {
               const option = new StringSelectMenuOptionBuilder()
                 .setLabel(`${s.name} - ${s.amount}`)
                 .setValue(s.id);
-              const parsed = parseEmoji(s.emoji);
-              if (parsed) {
-                option.setEmoji(parsed.id ? { id: parsed.id, animated: parsed.animated } : parsed.name);
+              if (s.emoji) {
+                option.setEmoji(s.emoji);
               }
               return option;
             }),


### PR DESCRIPTION
## Summary
- fix invalid emoji errors in farm planting menu by passing emoji directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76c40c5e883219bc45aa254a528f6