### PR TITLE
feat: show sale confirmation in market

### DIFF
--- a/command/shop.js
+++ b/command/shop.js
@@ -349,13 +349,14 @@ function setup(client, resources) {
         normalizeInventory(stats);
         resources.userStats[interaction.user.id] = stats;
         resources.saveData();
-        await interaction.update({
-          components: [
+        const container = new ContainerBuilder()
+          .setAccentColor(0x00ff00)
+          .addTextDisplayComponents(
             new TextDisplayBuilder().setContent(
-              `Sold **×${amount} ${entry.name} ${entry.emoji}** for ${total} ${coinEmoji}.`,
+              `Sold ×${amount} ${entry.name} ${entry.emoji} for ${total} ${coinEmoji}.`,
             ),
-          ],
-        });
+          );
+        await interaction.update({ components: [container] });
         try {
           const message = await interaction.channel.messages.fetch(messageId);
           await sendMarket(interaction.user, message.edit.bind(message), resources);


### PR DESCRIPTION
## Summary
- show sale result inside green container when selling items in market

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7f9eaa9dc832197a00b9f4c47671a