### PR TITLE
Shrink default shop UI dimensions

### DIFF
--- a/shopMedia.js
+++ b/shopMedia.js
@@ -205,8 +205,8 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
  * opts: {width,height}
  */
 async function renderShopMedia(items = [], opts = {}) {
-  const W = Math.max(800, opts.width || 1200);
-  const H = Math.max(600, opts.height || 800);
+  const W = Math.max(800, opts.width || 960);
+  const H = Math.max(600, opts.height || 640);
   const cols = 3, rows = 2;
 
   const canvas = createCanvas(W, H);

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -345,8 +345,8 @@ async function deluxeCard(ctx, x, y, w, h, item = {}) {
  * @returns Buffer (PNG)
  */
 async function renderDeluxeMedia(items = [], opts = {}) {
-  const W = Math.max(800, opts.width || 1200);
-  const H = Math.max(600, opts.height || 800);
+  const W = Math.max(800, opts.width || 960);
+  const H = Math.max(600, opts.height || 640);
   const cols = 3, rows = 2;
 
   const canvas = createCanvas(W, H);


### PR DESCRIPTION
## Summary
- Decrease default canvas size for standard shop rendering to 960x640
- Match deluxe shop rendering defaults to 960x640 for a more compact layout

## Testing
- `npm test` *(fails: command searched all node_modules and did not complete in reasonable time)*
- `node --check shopMedia.js`
- `node --check shopMediaDeluxe.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7fb350c78832183739d22504e0da2