### PR TITLE
Reduce shop UI default dimensions

### DIFF
--- a/shopMedia.js
+++ b/shopMedia.js
@@ -205,8 +205,8 @@ async function card(ctx, x, y, w, h, item = {}, coinImg) {
  * opts: {width,height}
  */
 async function renderShopMedia(items = [], opts = {}) {
-  const W = Math.max(800, opts.width || 960);
-  const H = Math.max(600, opts.height || 640);
+  const W = Math.max(600, opts.width || 600);
+  const H = Math.max(400, opts.height || 400);
   const cols = 3, rows = 2;
 
   const canvas = createCanvas(W, H);

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -345,8 +345,8 @@ async function deluxeCard(ctx, x, y, w, h, item = {}) {
  * @returns Buffer (PNG)
  */
 async function renderDeluxeMedia(items = [], opts = {}) {
-  const W = Math.max(800, opts.width || 960);
-  const H = Math.max(600, opts.height || 640);
+  const W = Math.max(600, opts.width || 600);
+  const H = Math.max(400, opts.height || 400);
   const cols = 3, rows = 2;
 
   const canvas = createCanvas(W, H);


### PR DESCRIPTION
## Summary
- Shrink normal shop default size to 600x400
- Shrink deluxe shop default size to 600x400

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7fd7eb33883219b253d2d5e31874a