### PR TITLE
Cache shop images locally

### DIFF
--- a/imageCache.js
+++ b/imageCache.js
@@ -1,0 +1,38 @@
+const { loadImage } = require('canvas');
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const CACHE_DIR = path.join(__dirname, 'image-cache');
+
+async function loadCachedImage(url) {
+  if (!url) return null;
+  const fsPromises = fs.promises;
+  const hash = crypto.createHash('md5').update(url).digest('hex');
+  let ext = '.png';
+  try {
+    const pathname = new URL(url).pathname;
+    const extname = path.extname(pathname);
+    if (extname) ext = extname;
+  } catch {
+    // ignore
+  }
+  const filePath = path.join(CACHE_DIR, `${hash}${ext}`);
+  try {
+    await fsPromises.access(filePath);
+    return loadImage(filePath);
+  } catch {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const arrayBuffer = await res.arrayBuffer();
+      await fsPromises.mkdir(CACHE_DIR, { recursive: true });
+      await fsPromises.writeFile(filePath, Buffer.from(arrayBuffer));
+      return loadImage(filePath);
+    } catch {
+      return loadImage(url);
+    }
+  }
+}
+
+module.exports = { loadCachedImage };

--- a/shopMedia.js
+++ b/shopMedia.js
@@ -3,7 +3,8 @@
 // Normal Shop (3x2). No header/tabs. Image is fully visible (contain-fit) and centered.
 // Coin icon uses a Discord emoji URL to ensure it loads correctly
 // npm i canvas
-const { createCanvas, loadImage } = require('canvas');
+const { createCanvas } = require('canvas');
+const { loadCachedImage } = require('./imageCache');
 
 /* ------------------------ helpers (unchanged) ------------------------ */
 function rrect(ctx, x, y, w, h, r = 16) {
@@ -67,7 +68,7 @@ async function drawContain(ctx, imgSrc, x, y, w, h, radius = 14) {
 
   if (imgSrc) {
     try {
-      const img = await loadImage(imgSrc);
+      const img = await loadCachedImage(imgSrc);
       const scale = Math.min(w / img.width, h / img.height);
       const dw = img.width * scale;
       const dh = img.height * scale;
@@ -245,7 +246,7 @@ async function renderShopMedia(items = [], opts = {}) {
   // preload coin image once
   let coinImg = null;
   try {
-    coinImg = await loadImage('https://cdn.discordapp.com/emojis/1405595571141480570.png?size=48&quality=lossless');
+    coinImg = await loadCachedImage('https://cdn.discordapp.com/emojis/1405595571141480570.png?size=48&quality=lossless');
   } catch {
     coinImg = null;
   }

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -2,7 +2,8 @@
 // Improved by Gemini: Converted static layout to a responsive, proportional design.
 // "Deluxe Shop" – premium 3x2 grid with gold accents only (no header/tabs)
 // npm i canvas
-const { createCanvas, loadImage } = require('canvas');
+const { createCanvas } = require('canvas');
+const { loadCachedImage } = require('./imageCache');
 
 /* ------------------------ helpers (unchanged) ------------------------ */
 function rrect(ctx, x, y, w, h, r = 18) {
@@ -66,7 +67,7 @@ async function drawCover(ctx, imgSrc, x, y, w, h, radius = 16) {
     ctx.fillRect(x, y, w, h);
   } else {
     try {
-      const img = await loadImage(imgSrc);
+      const img = await loadCachedImage(imgSrc);
       const s = Math.max(w / img.width, h / img.height);
       const dw = img.width * s;
       const dh = img.height * s;


### PR DESCRIPTION
## Summary
- avoid re-downloading shop images by caching them on disk
- use cached images for shop and deluxe shop renders

## Testing
- `npm test` *(fails: command scans node_modules and does not complete in reasonable time)*

------
https://chatgpt.com/codex/tasks/task_e_68a80fa0d2508321824cac224cf50ae6