### PR TITLE
Add per-item sell prices to items

### DIFF
--- a/command/shop.js
+++ b/command/shop.js
@@ -36,16 +36,14 @@ const SHOP_ITEMS = {
   deluxe: [],
 };
 
-const SELL_PRICES = {
-  Wheat: [50000, 100000],
-};
-
 const shopStates = new Map();
 
 async function sendMarket(user, send, resources) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   normalizeInventory(stats);
-  const sellable = (stats.inventory || []).filter(i => SELL_PRICES[i.id]);
+  const sellable = (stats.inventory || []).filter(
+    i => (ITEMS[i.id] || {}).sellPrice,
+  );
   const select = new StringSelectMenuBuilder()
     .setCustomId('market-sell-select')
     .setPlaceholder('Item to sell');
@@ -479,7 +477,8 @@ function setup(client, resources) {
         });
         return;
       }
-      const [min, max] = SELL_PRICES[itemId];
+      const item = ITEMS[itemId];
+      const [min, max] = item.sellPrice;
       const price = Math.floor(Math.random() * (max - min + 1)) + min;
       const total = price * amount;
       const coinEmoji = '<:CRCoin:1405595571141480570>';

--- a/items.js
+++ b/items.js
@@ -10,6 +10,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/zVykckz3/Padlock.png',
     price: 35000,
+    sellPrice: null,
   },
   TotemOfUndying: {
     id: 'TotemOfUndying',
@@ -22,6 +23,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/NdmDRzcs/Totem-Of-Undying.gif',
     price: 300000,
+    sellPrice: null,
   },
   Landmine: {
     id: 'Landmine',
@@ -34,6 +36,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/YBhRW2Hc/Landmine.png',
     price: 200000,
+    sellPrice: null,
   },
   WheatSeed: {
     id: 'WheatSeed',
@@ -46,6 +49,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/HTFCk0TN/Wheat-seed-package.png',
     price: 10000,
+    sellPrice: null,
   },
   HarvestScythe: {
     id: 'HarvestScythe',
@@ -58,6 +62,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/JwX0nz9c/Harvest-scythe.png',
     price: 120000,
+    sellPrice: null,
   },
   Wheat: {
     id: 'Wheat',
@@ -70,6 +75,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/60mfbHqp/Wheat.png',
     price: 0,
+    sellPrice: [50000, 100000],
   },
   WateringCan: {
     id: 'WateringCan',
@@ -82,6 +88,7 @@ const ITEMS = {
     note: '',
     image: 'https://i.ibb.co/Tqqq3fM7/Watering-Can.png',
     price: 70000,
+    sellPrice: null,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add `sellPrice` field to each item definition and configure Wheat's sell price range
- Update shop logic to rely on `sellPrice` for market listings and sales

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8226cb7ec8321b698ce5e1b60591a