### PR TITLE
Handle numeric sellPrice values in market

### DIFF
--- a/command/shop.js
+++ b/command/shop.js
@@ -478,7 +478,10 @@ function setup(client, resources) {
         return;
       }
       const item = ITEMS[itemId];
-      const [min, max] = item.sellPrice;
+      const sellPrice = item.sellPrice;
+      const [min, max] = Array.isArray(sellPrice)
+        ? sellPrice
+        : [sellPrice, sellPrice];
       const price = Math.floor(Math.random() * (max - min + 1)) + min;
       const total = price * amount;
       const coinEmoji = '<:CRCoin:1405595571141480570>';


### PR DESCRIPTION
## Summary
- Allow sellPrice in shop items to be a single number
- Avoid TypeError when selling items with fixed sell price

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a855b0ae448321ade03c870f98d761