### PR TITLE
Sync inventory entries with current item metadata

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -36,7 +36,7 @@ const levelUpChannelId = 1373578620634665052;
 const voiceSessions = new Map();
 const pendingRequests = new Map();
 
-function fixEmojiIds(statsMap) {
+function fixItemEntries(statsMap) {
   const itemsById = Object.fromEntries(
     Object.values(ITEMS).map(i => [i.id, i])
   );
@@ -50,11 +50,26 @@ function fixEmojiIds(statsMap) {
       let base = itemsById[item.id] ||
         (item.name && itemsByName[item.name.toLowerCase()]);
       if (!base) return item;
-      if (item.emoji !== base.emoji) {
-        fixed++;
-        return { ...item, emoji: base.emoji };
+      let changed = false;
+      const updated = { ...item };
+      if (item.id !== base.id) {
+        updated.id = base.id;
+        changed = true;
       }
-      return item;
+      if (item.emoji !== base.emoji) {
+        updated.emoji = base.emoji;
+        changed = true;
+      }
+      if (item.name !== base.name) {
+        updated.name = base.name;
+        changed = true;
+      }
+      if (item.image !== base.image) {
+        updated.image = base.image;
+        changed = true;
+      }
+      if (changed) fixed++;
+      return changed ? updated : item;
     });
   }
   return fixed;
@@ -71,10 +86,10 @@ function loadData() {
     userCardSettings = {};
     timedRoles = [];
   }
-  const fixed = fixEmojiIds(userStats);
+  const fixed = fixItemEntries(userStats);
   if (fixed > 0) {
     saveData();
-    console.log(`Fixed ${fixed} emoji entries.`);
+    console.log(`Fixed ${fixed} inventory entries.`);
   }
 }
 

--- a/updateEmojiIds.js
+++ b/updateEmojiIds.js
@@ -34,6 +34,10 @@ for (const stats of Object.values(userStats)) {
 
     const updated = { ...item };
     let changed = false;
+    if (item.id !== base.id) {
+      updated.id = base.id;
+      changed = true;
+    }
     if (item.emoji !== base.emoji) {
       updated.emoji = base.emoji;
       changed = true;
@@ -53,7 +57,7 @@ for (const stats of Object.values(userStats)) {
 
 if (fixed > 0) {
   fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
-  console.log(`Fixed ${fixed} emoji entries.`);
+  console.log(`Fixed ${fixed} item entries.`);
 } else {
-  console.log('No emoji entries needed fixing.');
+  console.log('No inventory entries needed fixing.');
 }


### PR DESCRIPTION
## Summary
- update inventory cleanup script to also refresh item ids
- load user data with automatic inventory item metadata correction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af0e20a7548321bb572cb48d4daff8