### PR TITLE
Fix add-role command component usage

### DIFF
--- a/command/addRole.js
+++ b/command/addRole.js
@@ -3,7 +3,7 @@ const {
   PermissionFlagsBits,
   MessageFlags,
   TextDisplayBuilder,
-  ActionRowBuilder,
+  ContainerBuilder,
 } = require('discord.js');
 
 const WARN = '<:SBWarning:1404101025849147432> ';
@@ -37,18 +37,24 @@ function setup(client, { scheduleRole }) {
       await user.roles.add(role);
       await interaction.editReply({
         components: [
-          new ActionRowBuilder().addComponents(
-            new TextDisplayBuilder().setContent(`Added ${role} to ${user}.`),
-          ),
+          new ContainerBuilder()
+            .setAccentColor(0xffffff)
+            .addTextDisplayComponents(
+              new TextDisplayBuilder().setContent(`Added ${role} to ${user}.`),
+            ),
         ],
+        flags: MessageFlags.IsComponentsV2,
       });
     } catch (err) {
       await interaction.editReply({
         components: [
-          new ActionRowBuilder().addComponents(
-            new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`),
-          ),
+          new ContainerBuilder()
+            .setAccentColor(0xffffff)
+            .addTextDisplayComponents(
+              new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`),
+            ),
         ],
+        flags: MessageFlags.IsComponentsV2,
       });
       return;
     }
@@ -57,9 +63,11 @@ function setup(client, { scheduleRole }) {
       if (!seconds) {
         await interaction.followUp({
           components: [
-            new ActionRowBuilder().addComponents(
-              new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`),
-            ),
+            new ContainerBuilder()
+              .setAccentColor(0xffffff)
+              .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`),
+              ),
           ],
           flags: MessageFlags.IsComponentsV2,
         });
@@ -75,11 +83,13 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   if (args.length < 2) {
     await message.channel.send({
       components: [
-        new ActionRowBuilder().addComponents(
-          new TextDisplayBuilder().setContent(
-            `${WARN}Usage: a. add role [userID] [roleID] [time]`,
+        new ContainerBuilder()
+          .setAccentColor(0xffffff)
+          .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+              `${WARN}Usage: a. add role [userID] [roleID] [time]`,
+            ),
           ),
-        ),
       ],
       flags: MessageFlags.IsComponentsV2,
     });
@@ -93,9 +103,11 @@ async function handleTextCommand(message, args, { scheduleRole }) {
   if (!member || !role) {
     await message.channel.send({
       components: [
-        new ActionRowBuilder().addComponents(
-          new TextDisplayBuilder().setContent(`${WARN}Invalid user or role ID.`),
-        ),
+        new ContainerBuilder()
+          .setAccentColor(0xffffff)
+          .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(`${WARN}Invalid user or role ID.`),
+          ),
       ],
       flags: MessageFlags.IsComponentsV2,
     });
@@ -106,18 +118,22 @@ async function handleTextCommand(message, args, { scheduleRole }) {
     await member.roles.add(role);
     await message.channel.send({
       components: [
-        new ActionRowBuilder().addComponents(
-          new TextDisplayBuilder().setContent(`Added ${role} to <@${userId}>.`),
-        ),
+        new ContainerBuilder()
+          .setAccentColor(0xffffff)
+          .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(`Added ${role} to <@${userId}>.`),
+          ),
       ],
       flags: MessageFlags.IsComponentsV2,
     });
   } catch {
     await message.channel.send({
       components: [
-        new ActionRowBuilder().addComponents(
-          new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`),
-        ),
+        new ContainerBuilder()
+          .setAccentColor(0xffffff)
+          .addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(`${WARN}Failed to assign the role.`),
+          ),
       ],
       flags: MessageFlags.IsComponentsV2,
     });
@@ -129,9 +145,11 @@ async function handleTextCommand(message, args, { scheduleRole }) {
     if (!seconds) {
       await message.channel.send({
         components: [
-          new ActionRowBuilder().addComponents(
-            new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`),
-          ),
+          new ContainerBuilder()
+            .setAccentColor(0xffffff)
+            .addTextDisplayComponents(
+              new TextDisplayBuilder().setContent(`${WARN}Invalid time format.`),
+            ),
         ],
         flags: MessageFlags.IsComponentsV2,
       });


### PR DESCRIPTION
## Summary
- use `ContainerBuilder` and `TextDisplayBuilder` for add-role responses
- ensure messages include Components V2 flag

## Testing
- `node --check command/addRole.js`
- `timeout 30 npm test` *(fails: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68af2dae15e88321a001478236f2fa4c