### PR TITLE
Add startup script to auto-install Node 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,20 +4,14 @@ This is a simple Discord bot rewritten in JavaScript using [`discord.js`](https:
 
 ## Setup
 
-1. Install dependencies:
-
-   ```bash
-   npm install
-   ```
-
-2. Create a `.env` file with your bot token and the role ID allowed to use admin commands:
+1. Create a `.env` file with your bot token and the role ID allowed to use admin commands:
 
    ```env
    BOT_TOKEN=your_bot_token_here
    ADMIN_ROLE_ID=role_id_allowed_to_manage_currency_and_items
    ```
 
-3. Run the bot:
+2. Run the bot (it will install Node.js 22 and any dependencies automatically):
 
    ```bash
    npm start

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bot.js",
   "type": "commonjs",
   "scripts": {
-    "start": "node bot.js",
+    "start": "bash start.sh",
     "test": "find . -name '*.js' -print0 | xargs -0 -n1 node --check"
   },
   "engines": {

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+REQUIRED_VERSION="22.0.0"
+REQUIRED_MAJOR=22
+
+# Get current Node major version, or empty if Node not installed
+CURRENT_MAJOR=$(node -v 2>/dev/null | sed 's/^v//' | cut -d'.' -f1)
+
+if [ -z "$CURRENT_MAJOR" ] || [ "$CURRENT_MAJOR" -lt "$REQUIRED_MAJOR" ]; then
+  echo "Installing Node.js v$REQUIRED_VERSION..."
+  export NVM_DIR="$HOME/.nvm"
+  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+    echo "nvm not found; installing..."
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash >/tmp/nvm-install.log && tail -n 20 /tmp/nvm-install.log
+  fi
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+  nvm install "$REQUIRED_VERSION"
+  nvm use "$REQUIRED_VERSION"
+else
+  echo "Using existing Node.js $(node -v)"
+fi
+
+npm install
+node bot.js


### PR DESCRIPTION
## Summary
- add `start.sh` which installs Node.js 22 with nvm, installs dependencies, then launches the bot
- direct `npm start` to run the new script
- document automatic startup process in README

## Testing
- `timeout 15 npm test` *(timed out: scans all JS files, including node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b1778dcf24832189f286370aec0f44