### PR TITLE
fix: ensure shop updates use components v2

### DIFF
--- a/command/shop.js
+++ b/command/shop.js
@@ -375,6 +375,7 @@ function setup(client, resources) {
                 new TextDisplayBuilder().setContent('Item not available.'),
               ),
             ],
+            flags: MessageFlags.IsComponentsV2,
           });
           return;
         }
@@ -392,6 +393,7 @@ function setup(client, resources) {
                 ),
               ),
             ],
+            flags: MessageFlags.IsComponentsV2,
           });
           return;
         }
@@ -423,7 +425,7 @@ function setup(client, resources) {
                 ),
               ),
           );
-        await interaction.update({ components: [container] });
+        await interaction.update({ components: [container], flags: MessageFlags.IsComponentsV2 });
       } else if (interaction.customId === 'shop-cancel') {
         const pending = resources.pendingRequests.get(interaction.user.id);
         if (pending) clearTimeout(pending.timer);
@@ -448,6 +450,7 @@ function setup(client, resources) {
                 new TextDisplayBuilder().setContent('Sale failed.'),
               ),
             ],
+            flags: MessageFlags.IsComponentsV2,
           });
           return;
         }
@@ -465,7 +468,7 @@ function setup(client, resources) {
               `Sold ×${amount} ${entry.name} ${entry.emoji} for ${total} ${coinEmoji}.`,
             ),
           );
-        await interaction.update({ components: [container] });
+        await interaction.update({ components: [container], flags: MessageFlags.IsComponentsV2 });
         try {
           const message = await interaction.channel.messages.fetch(messageId);
           await sendMarket(interaction.user, message.edit.bind(message), resources);


### PR DESCRIPTION
## Summary
- prevent CombinedError when updating shop interactions by adding components v2 flag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac2ee67083218b87dd6760498de4