### PR TITLE
Fix progress bar rendering and NaN XP level bug

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -108,11 +108,20 @@ function saveData() {
 }
 
 function xpNeeded(level) {
-  return Math.floor(100 * Math.pow(level, 1.5));
+  const lvl = Number(level);
+  const n = Number.isFinite(lvl) && lvl > 0 ? lvl : 1;
+  return Math.floor(100 * Math.pow(n, 1.5));
 }
 
 async function addXp(user, amount, client) {
-  const stats = userStats[user.id] || { level:1, xp:0, total_xp:0, coins:0, diamonds:0, deluxe_coins:0 };
+  const stats = userStats[user.id] || {};
+  stats.level = Number.isFinite(stats.level) && stats.level > 0 ? stats.level : 1;
+  stats.xp = Number.isFinite(stats.xp) ? stats.xp : 0;
+  stats.total_xp = Number.isFinite(stats.total_xp) ? stats.total_xp : 0;
+  stats.coins = Number.isFinite(stats.coins) ? stats.coins : 0;
+  stats.diamonds = Number.isFinite(stats.diamonds) ? stats.diamonds : 0;
+  stats.deluxe_coins = Number.isFinite(stats.deluxe_coins) ? stats.deluxe_coins : 0;
+
   stats.xp += amount;
   stats.total_xp += amount;
   let prev = stats.level;

--- a/command/level.js
+++ b/command/level.js
@@ -20,7 +20,11 @@ const { loadImage } = require('canvas');
 const WARN = '<:SBWarning:1404101025849147432> ';
 
 async function sendLevelCard(user, send, { userStats, userCardSettings, saveData, xpNeeded, defaultColor, defaultBackground }) {
-  const stats = userStats[user.id] || { level:1, xp:0, total_xp:0, prestige:0 };
+  const stats = userStats[user.id] || {};
+  stats.level = Number.isFinite(stats.level) && stats.level > 0 ? stats.level : 1;
+  stats.xp = Number.isFinite(stats.xp) ? stats.xp : 0;
+  stats.total_xp = Number.isFinite(stats.total_xp) ? stats.total_xp : 0;
+  stats.prestige = Number.isFinite(stats.prestige) ? stats.prestige : 0;
   const settings = userCardSettings[user.id] || { color: defaultColor, background_url: defaultBackground };
   userStats[user.id] = stats;
   userCardSettings[user.id] = settings;

--- a/levelCard.js
+++ b/levelCard.js
@@ -69,22 +69,14 @@ function drawProgressBar(ctx, x, y, w, h, progress, label, starImg, color) {
     grad.addColorStop(1, col);
     ctx.fillStyle = grad;
 
-    if (progress >= 1) {
-      // full progress retains rounded corners
-      roundRect(ctx, x, y, fillW, h, h / 2);
-      ctx.fill();
-    } else {
-      // left side rounded, right side square
-      const rads = h / 2;
-      ctx.beginPath();
-      ctx.moveTo(x + rads, y);
-      ctx.arcTo(x, y, x, y + h, rads);
-      ctx.arcTo(x, y + h, x + rads, y + h, rads);
-      ctx.lineTo(x + fillW, y + h);
-      ctx.lineTo(x + fillW, y);
-      ctx.closePath();
-      ctx.fill();
-    }
+    // draw full rounded bar, clipped to progress width for smooth edges
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(x, y, fillW, h);
+    ctx.clip();
+    roundRect(ctx, x, y, w, h, h / 2);
+    ctx.fill();
+    ctx.restore();
   }
 
   // Star icon


### PR DESCRIPTION
## Summary
- Smooth progress bar fill for level card
- Sanitize level stats to prevent NaN XP requirements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1dde424d483218e3a1fdac6d74578