### PR TITLE
Avoid timeout overflow for long timers

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -25,6 +25,7 @@ const addItemCommand = require('./command/addItem');
 const farmViewCommand = require('./command/farmView');
 const huntCommand = require('./command/hunt');
 const { ITEMS } = require('./items');
+const { setSafeTimeout } = require('./utils');
 
 const DATA_FILE = 'user_data.json';
 let userStats = {};
@@ -157,14 +158,14 @@ function scheduleRole(userId, guildId, roleId, expiresAt, save=false) {
     saveData();
   }
   const delay = expiresAt * 1000 - Date.now();
-  setTimeout(async () => {
+  setSafeTimeout(async () => {
     try {
       const guild = client.guilds.cache.get(guildId);
       if (!guild) return;
       const member = await guild.members.fetch(userId);
       await member.roles.remove(roleId);
     } catch (err) {}
-  }, Math.max(delay, 0));
+  }, delay);
 }
 
 loadData();

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -14,7 +14,7 @@ const {
   TextInputStyle,
 } = require('discord.js');
 const { ITEMS } = require('../items');
-const { normalizeInventory } = require('../utils');
+const { normalizeInventory, setSafeTimeout } = require('../utils');
 
 const WARNING = '<:SBWarning:1404101025849147432>';
 const DIAMOND_EMOJI = '<:CRDiamond:1405595593069432912>';
@@ -113,7 +113,7 @@ function expiredPadlockContainer(user, disable = false) {
 
 function schedulePadlock(user, expiresAt, resources) {
   const delay = expiresAt - Date.now();
-  setTimeout(async () => {
+  setSafeTimeout(async () => {
     const stats = resources.userStats[user.id];
     if (stats && stats.padlock_until === expiresAt) {
       stats.padlock_until = 0;
@@ -122,18 +122,18 @@ function schedulePadlock(user, expiresAt, resources) {
     try {
       await user.send({ components: [expiredPadlockContainer(user)], flags: MessageFlags.IsComponentsV2 });
     } catch {}
-  }, Math.max(delay, 0));
+  }, delay);
 }
 
 function scheduleLandmine(user, expiresAt, resources) {
   const delay = expiresAt - Date.now();
-  setTimeout(() => {
+  setSafeTimeout(() => {
     const stats = resources.userStats[user.id];
     if (stats && stats.landmine_until === expiresAt) {
       stats.landmine_until = 0;
       resources.saveData();
     }
-  }, Math.max(delay, 0));
+  }, delay);
 }
 
 async function restoreActiveItemTimers(client, resources) {

--- a/utils.js
+++ b/utils.js
@@ -67,4 +67,11 @@ function normalizeInventory(stats) {
   stats.inventory = Object.values(map).filter(i => (i.amount || 0) > 0);
 }
 
-module.exports = { formatNumber, parseAmount, normalizeInventory };
+const MAX_TIMEOUT = 2 ** 31 - 1;
+
+function setSafeTimeout(fn, delay) {
+  if (delay <= MAX_TIMEOUT) return setTimeout(fn, Math.max(0, delay));
+  return setTimeout(() => setSafeTimeout(fn, delay - MAX_TIMEOUT), MAX_TIMEOUT);
+}
+
+module.exports = { formatNumber, parseAmount, normalizeInventory, setSafeTimeout };


### PR DESCRIPTION
## Summary
- add `setSafeTimeout` utility that schedules callbacks beyond Node's timeout limit
- use `setSafeTimeout` for role, padlock, and landmine expiry timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f1ce4b2c8321a94585d098cdbb90