### PR TITLE
fix: handle level ups when viewing level card

### DIFF
--- a/command/level.js
+++ b/command/level.js
@@ -18,6 +18,7 @@ const { renderLevelCard } = require('../levelCard');
 const { loadImage } = require('canvas');
 
 const WARN = '<:SBWarning:1404101025849147432> ';
+const MAX_LEVEL = 9999;
 
 async function sendLevelCard(user, send, { userStats, userCardSettings, saveData, xpNeeded, defaultColor, defaultBackground }) {
   const stats = userStats[user.id] || {};
@@ -25,6 +26,10 @@ async function sendLevelCard(user, send, { userStats, userCardSettings, saveData
   stats.xp = Number.isFinite(stats.xp) ? stats.xp : 0;
   stats.total_xp = Number.isFinite(stats.total_xp) ? stats.total_xp : 0;
   stats.prestige = Number.isFinite(stats.prestige) ? stats.prestige : 0;
+  while (stats.level < MAX_LEVEL && stats.xp >= xpNeeded(stats.level)) {
+    stats.xp -= xpNeeded(stats.level);
+    stats.level += 1;
+  }
   const settings = userCardSettings[user.id] || { color: defaultColor, background_url: defaultBackground };
   userStats[user.id] = stats;
   userCardSettings[user.id] = settings;


### PR DESCRIPTION
## Summary
- ensure `/level` recalculates level if stored XP exceeds requirement
- cap recalculations to MAX_LEVEL to avoid runaway loops

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f433ea6c8321a8848b363c14ee74