### PR TITLE
Fix hunt reply handling and import animal items

### DIFF
--- a/animals.js
+++ b/animals.js
@@ -8,7 +8,8 @@ function loadAnimals() {
   for (let i = 1; i < rows.length; i++) {
     const row = rows[i];
     if (!row || !row[0]) continue;
-    const id = row[17] || String(row[0]).replace(/\s+/g, '');
+    const id = row[17];
+    if (!id) continue;
     animals.push({
       id,
       name: row[0],
@@ -39,7 +40,7 @@ const ANIMAL_ITEMS = Object.fromEntries(
       rarity: a.rarity,
       value: a.value,
       useable: false,
-      type: 'Animal',
+      type: 'Misc',
       note: '',
       image: '',
       price: 0,

--- a/command/hunt.js
+++ b/command/hunt.js
@@ -286,7 +286,7 @@ function pickAnimal(areaKey, tier) {
   return candidates[candidates.length - 1].animal;
 }
 
-async function sendHunt(user, send, resources) {
+async function sendHunt(user, send, resources, fetchReply) {
   const stats = resources.userStats[user.id] || { inventory: [] };
   resources.userStats[user.id] = stats;
   const areaObj = getArea(stats.hunt_area);
@@ -300,11 +300,13 @@ async function sendHunt(user, send, resources) {
     0xffffff,
     areaObj && areaObj.image,
   );
-  const message = await send({
+  let message = await send({
     components: [container],
     flags: MessageFlags.IsComponentsV2,
-    fetchReply: true,
   });
+  if (fetchReply) {
+    message = await fetchReply();
+  }
   huntStates.set(message.id, { userId: user.id });
   return message;
 }
@@ -392,6 +394,7 @@ function setup(client, resources) {
           interaction.user,
           interaction.reply.bind(interaction),
           resources,
+          interaction.fetchReply.bind(interaction),
         );
       } else if (
         interaction.isStringSelectMenu() &&


### PR DESCRIPTION
## Summary
- replace deprecated `fetchReply` option in hunt command with follow-up fetch call
- load animal items from spreadsheet using column R IDs and mark them as `Misc`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a36a3cd8832183a5ab8f5d7b8e46