### PR TITLE
Refactor updateEmojiIds to sync item metadata

### DIFF
--- a/updateEmojiIds.js
+++ b/updateEmojiIds.js
@@ -21,6 +21,9 @@ const itemsByName = Object.fromEntries(
   Object.values(ITEMS).map(i => [i.name.toLowerCase(), i])
 );
 
+// Fields to synchronise with item definitions
+const SYNC_FIELDS = ['id', 'emoji', 'image', 'name', 'rarity', 'type', 'value'];
+
 let fixed = 0;
 
 for (const stats of Object.values(userStats)) {
@@ -34,34 +37,14 @@ for (const stats of Object.values(userStats)) {
 
     const updated = { ...item };
     let changed = false;
-    if (item.id !== base.id) {
-      updated.id = base.id;
-      changed = true;
+
+    for (const field of SYNC_FIELDS) {
+      if (item[field] !== base[field]) {
+        updated[field] = base[field];
+        changed = true;
+      }
     }
-    if (item.emoji !== base.emoji) {
-      updated.emoji = base.emoji;
-      changed = true;
-    }
-    if (item.image !== base.image) {
-      updated.image = base.image;
-      changed = true;
-    }
-    if (item.name !== base.name) {
-      updated.name = base.name;
-      changed = true;
-    }
-    if (item.rarity !== base.rarity) {
-      updated.rarity = base.rarity;
-      changed = true;
-    }
-    if (item.type !== base.type) {
-      updated.type = base.type;
-      changed = true;
-    }
-    if (item.value !== base.value) {
-      updated.value = base.value;
-      changed = true;
-    }
+
     if (changed) fixed++;
     return updated;
   });


### PR DESCRIPTION
## Summary
- streamline inventory fixer to sync id, emoji, image, name, rarity, type and value with canonical item data

## Testing
- `npm test`
- `node updateEmojiIds.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2acf9479083218c981362997897be