### PR TITLE
Fix undefined item metadata in inventory

### DIFF
--- a/command/hunt.js
+++ b/command/hunt.js
@@ -345,14 +345,7 @@ async function handleHunt(message, user, resources, stats) {
     const item = ITEMS[animal.id];
     const existing = (stats.inventory || []).find(i => i.id === item.id);
     if (existing) existing.amount += 1;
-    else
-      (stats.inventory = stats.inventory || []).push({
-        id: item.id,
-        name: item.name,
-        emoji: item.emoji,
-        image: item.image,
-        amount: 1,
-      });
+    else (stats.inventory = stats.inventory || []).push({ ...item, amount: 1 });
     normalizeInventory(stats);
     const art = articleFor(animal.name);
     color = RARITY_COLORS[animal.rarity] || 0xffffff;

--- a/command/useItem.js
+++ b/command/useItem.js
@@ -289,14 +289,7 @@ function useBulletBox(user, amount, resources) {
   const bulletItem = ITEMS.Bullet;
   const gained = 6 * amount;
   if (bullet) bullet.amount += gained;
-  else
-    stats.inventory.push({
-      id: 'Bullet',
-      name: bulletItem.name,
-      emoji: bulletItem.emoji,
-      image: bulletItem.image,
-      amount: gained,
-    });
+  else stats.inventory.push({ ...bulletItem, amount: gained });
   normalizeInventory(stats);
   resources.userStats[user.id] = stats;
   resources.saveData();

--- a/utils.js
+++ b/utils.js
@@ -36,6 +36,8 @@ const PARSE_MAP = {
   No: 1e30,
 };
 
+const { ITEMS } = require('./items');
+
 function parseAmount(str) {
   const match = String(str).trim().match(/^(-?\d+(?:\.\d+)?)([a-zA-Z]{1,2})?$/);
   if (!match) return NaN;
@@ -59,9 +61,11 @@ function normalizeInventory(stats) {
   const map = {};
   for (const item of stats.inventory) {
     if (!item || !item.id) continue;
-    const id = item.id;
-    const amount = item.amount || 0;
-    if (!map[id]) map[id] = { ...item, amount };
+    const base = ITEMS[item.id] || {};
+    const merged = { ...base, ...item };
+    const id = merged.id;
+    const amount = merged.amount || 0;
+    if (!map[id]) map[id] = { ...merged, amount };
     else map[id].amount += amount;
   }
   stats.inventory = Object.values(map).filter(i => (i.amount || 0) > 0);


### PR DESCRIPTION
## Summary
- merge item metadata during inventory normalization
- include full item data when adding loot from hunts or bullet boxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ae9ef7d8832193e92f3841406a8e