### PR TITLE
Add digging command and refresh item types

### DIFF
--- a/animals.js
+++ b/animals.js
@@ -40,7 +40,7 @@ const ANIMAL_ITEMS = Object.fromEntries(
       rarity: a.rarity,
       value: a.value,
       useable: false,
-      type: 'Misc',
+      types: ['Sellable'],
       note: '',
       image: '',
       price: 0,

--- a/bot.js
+++ b/bot.js
@@ -24,6 +24,7 @@ const addCurrencyCommand = require('./command/addCurrency');
 const addItemCommand = require('./command/addItem');
 const farmViewCommand = require('./command/farmView');
 const huntCommand = require('./command/hunt');
+const digCommand = require('./command/dig');
 const { ITEMS } = require('./items');
 const { setSafeTimeout } = require('./utils');
 
@@ -262,6 +263,7 @@ client.on = function(event, listener) {
     addItemCommand.setup(client, resources);
     farmViewCommand.setup(client, resources);
     huntCommand.setup(client, resources);
+    digCommand.setup(client, resources);
     timedRoles.forEach(r => scheduleRole(r.user_id, r.guild_id, r.role_id, r.expires_at));
 
     // Remove deprecated /level-button command if it exists

--- a/command/dig.js
+++ b/command/dig.js
@@ -1,0 +1,277 @@
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  ContainerBuilder,
+  SectionBuilder,
+  ThumbnailBuilder,
+  SeparatorBuilder,
+  TextDisplayBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} = require('discord.js');
+const { ITEMS, DIG_ITEMS } = require('../items');
+const { normalizeInventory } = require('../utils');
+
+const THUMB_URL = 'https://i.ibb.co/G4cSsHHN/dig-symbol.png';
+const COIN_EMOJI = '<:CRCoin:1405595571141480570>';
+const DIG_STAT_EMOJI = '<:SBDig:1412452052721995868>';
+const FAIL_MESSAGES = [
+  '🪨 Your shovel hits a BIG rock… and nothing else.',
+  '🐛 You dig up a handful of worms. You stupidly think it is not exactly treasure.',
+  '💧 Water seeps into the hole, and you give up before drowning your loot.',
+  '🕳️ After digging for ages, the hole is empty. Just dirt.',
+  '🦴 You unearth old animal bones… creepy, but worthless.',
+  '🌱 A stubborn tree root blocks your shovel—you can’t dig any further.',
+  '🪣 Your shovel handle snaps in half. Time to go home.',
+  '🐀 A rat leaps out of the hole and you drop everything in panic.',
+  '🪵 You just dug up a rotten log. Congratulations.',
+  '🪦 You accidentally disturb a grave marker… you quickly rebury it in fear.',
+  '🍄 You find mushrooms growing in the soil. They don’t look edible.',
+  '🐜 An army of ants swarms out of the hole—you run off itching.',
+  '💨 You dig for hours, but the dirt just keeps collapsing back in.',
+  '🦆 You dug straight into a duck nest—the angry bird chases you away.',
+  '🕷️ A giant spider crawls out of the hole. Nope. You’re done.',
+  '🎋 You only uncover roots and weeds. Nothing useful.',
+  '🦨 You disturb a skunk burrow… the smell makes you abandon everything.',
+  '🔒 You actually find a rusty chest… but the lock is fused shut and won’t open.',
+  '📜 You uncover scraps of paper too soggy to read.',
+  '🧱 Your shovel clangs against buried bricks—you can’t break through.',
+];
+
+const RARITY_EMOJIS = {
+  Common: '<:SBRCommon:1409932856762826862>',
+  Rare: '<:SBRRare:1409932954037387324>',
+  Epic: '<:SBREpic:1409933003269996674>',
+  Legendary: '<a:SBRLegendary:1409933036568449105>',
+  Mythical: '<a:SBRMythical:1409933097176268902>',
+  Godly: '<a:SBRGodly:1409933130793750548>',
+  Prismatic: '<a:SBRPrismatic:1409933176276521010>',
+  Secret: '<a:SBRSecret:1409933447220297791>',
+};
+
+const digStates = new Map();
+
+function getRandomDigItem() {
+  const total = DIG_ITEMS.reduce((sum, it) => sum + (it.chance || 0), 0);
+  const r = Math.random() * total;
+  let acc = 0;
+  for (const it of DIG_ITEMS) {
+    acc += it.chance || 0;
+    if (r < acc) return it;
+  }
+  return null;
+}
+
+function buildMainContainer(user, text, color, disable = false) {
+  const digBtn = new ButtonBuilder()
+    .setCustomId('dig-action')
+    .setLabel('Dig')
+    .setStyle(ButtonStyle.Danger)
+    .setEmoji(ITEMS.Shovel.emoji);
+  const statBtn = new ButtonBuilder()
+    .setCustomId('dig-stat')
+    .setLabel('Dig Stat')
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji(DIG_STAT_EMOJI);
+  const equipBtn = new ButtonBuilder()
+    .setCustomId('dig-equipment')
+    .setLabel('Equipment')
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji(DIG_STAT_EMOJI);
+  if (disable) {
+    digBtn.setDisabled(true);
+    statBtn.setDisabled(true);
+    equipBtn.setDisabled(true);
+  }
+  const section = new SectionBuilder()
+    .setThumbnailAccessory(new ThumbnailBuilder().setURL(THUMB_URL))
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(text));
+  return new ContainerBuilder()
+    .setAccentColor(color)
+    .addSectionComponents(section)
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addActionRowComponents(
+      new ActionRowBuilder().addComponents(digBtn, statBtn, equipBtn),
+    );
+}
+
+function buildStatContainer(user, stats) {
+  const backBtn = new ButtonBuilder()
+    .setCustomId('dig-back')
+    .setLabel('Back')
+    .setStyle(ButtonStyle.Secondary);
+  const statBtn = new ButtonBuilder()
+    .setCustomId('dig-stat')
+    .setLabel('Dig Stat')
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(true)
+    .setEmoji(DIG_STAT_EMOJI);
+  const equipBtn = new ButtonBuilder()
+    .setCustomId('dig-equipment')
+    .setLabel('Equipment')
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji(DIG_STAT_EMOJI);
+  const section = new SectionBuilder()
+    .setThumbnailAccessory(new ThumbnailBuilder().setURL(user.displayAvatarURL()))
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(`## ${user} Digging Stats.`),
+      new TextDisplayBuilder().setContent(`* Dug ${stats.dig_total || 0} times`),
+      new TextDisplayBuilder().setContent(`* Succeed ${stats.dig_success || 0} times`),
+      new TextDisplayBuilder().setContent(`* Failed ${stats.dig_fail || 0} times`),
+    );
+  return new ContainerBuilder()
+    .setAccentColor(0xffffff)
+    .addSectionComponents(section)
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addActionRowComponents(
+      new ActionRowBuilder().addComponents(backBtn, statBtn, equipBtn),
+    );
+}
+
+function buildEquipmentContainer(user, stats) {
+  const backBtn = new ButtonBuilder()
+    .setCustomId('dig-back')
+    .setLabel('Back')
+    .setStyle(ButtonStyle.Secondary);
+  const statBtn = new ButtonBuilder()
+    .setCustomId('dig-stat')
+    .setLabel('Dig Stat')
+    .setStyle(ButtonStyle.Secondary)
+    .setEmoji(DIG_STAT_EMOJI);
+  const equipBtn = new ButtonBuilder()
+    .setCustomId('dig-equipment')
+    .setLabel('Equipment')
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(true)
+    .setEmoji(DIG_STAT_EMOJI);
+  const shovelEntry = (stats.inventory || []).find(i => i.id === 'Shovel');
+  const count = shovelEntry ? shovelEntry.amount : 0;
+  const text = count
+    ? `### You have ×${count} ${ITEMS.Shovel.name} ${ITEMS.Shovel.emoji}`
+    : `### You have no ${ITEMS.Shovel.name}.`;
+  const section = new SectionBuilder()
+    .setThumbnailAccessory(new ThumbnailBuilder().setURL(THUMB_URL))
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(text));
+  return new ContainerBuilder()
+    .setAccentColor(0xffffff)
+    .addSectionComponents(section)
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addActionRowComponents(
+      new ActionRowBuilder().addComponents(backBtn, statBtn, equipBtn),
+    );
+}
+
+async function handleDig(message, user, resources, stats) {
+  const success = Math.random() < 0.5;
+  stats.dig_total = (stats.dig_total || 0) + 1;
+  let text;
+  let color;
+  if (success) {
+    const amount = Math.floor(Math.random() * 4001) + 1000;
+    stats.coins = (stats.coins || 0) + amount;
+    stats.dig_success = (stats.dig_success || 0) + 1;
+    let extra = '';
+    if (Math.random() < 0.15) {
+      const item = getRandomDigItem();
+      if (item) {
+        stats.inventory = stats.inventory || [];
+        const entry = stats.inventory.find(i => i.id === item.id);
+        if (entry) entry.amount += 1;
+        else stats.inventory.push({ ...item, amount: 1 });
+        extra = `\n-# You also found **${item.name} ${item.emoji}** while digging! ${
+          RARITY_EMOJIS[item.rarity] || ''
+        }`;
+      }
+    }
+    text = `${user}, you have digged up **${amount} Coins ${COIN_EMOJI}!**${extra}`;
+    color = 0x00ff00;
+  } else {
+    stats.dig_fail = (stats.dig_fail || 0) + 1;
+    text = FAIL_MESSAGES[Math.floor(Math.random() * FAIL_MESSAGES.length)];
+    color = 0xff0000;
+  }
+  normalizeInventory(stats);
+  resources.userStats[user.id] = stats;
+  resources.saveData();
+  const container = buildMainContainer(user, text, color, false);
+  await message.edit({ components: [container], flags: MessageFlags.IsComponentsV2 });
+}
+
+function setup(client, resources) {
+  const command = new SlashCommandBuilder()
+    .setName('dig')
+    .setDescription('Dig for coins and items');
+  client.application.commands.create(command);
+
+  client.on('interactionCreate', async interaction => {
+    try {
+      if (!interaction.isChatInputCommand() || interaction.commandName !== 'dig') return;
+      await interaction.deferReply({ flags: MessageFlags.IsComponentsV2 });
+      const stats = resources.userStats[interaction.user.id] || { inventory: [] };
+      normalizeInventory(stats);
+      const container = buildMainContainer(
+        interaction.user,
+        `${interaction.user}, ready for digging?`,
+        0xffffff,
+      );
+      const message = await interaction.editReply({ components: [container] });
+      digStates.set(message.id, { userId: interaction.user.id });
+    } catch (error) {
+      if (error.code !== 10062) console.error(error);
+    }
+  });
+
+  client.on('interactionCreate', async interaction => {
+    const state = digStates.get(interaction.message?.id);
+    if (!state || interaction.user.id !== state.userId) return;
+    try {
+      if (interaction.isButton() && interaction.customId === 'dig-action') {
+        const stats = resources.userStats[state.userId] || { inventory: [] };
+        const loading = buildMainContainer(
+          interaction.user,
+          'You are going for a dig... <a:Digani:1412451477309620316>',
+          0x000000,
+          true,
+        );
+        await interaction.update({
+          components: [loading],
+          flags: MessageFlags.IsComponentsV2,
+        });
+        setTimeout(() => {
+          handleDig(interaction.message, interaction.user, resources, stats);
+        }, 3000);
+      } else if (interaction.isButton() && interaction.customId === 'dig-stat') {
+        const stats = resources.userStats[state.userId] || {};
+        const container = buildStatContainer(interaction.user, stats);
+        await interaction.update({
+          components: [container],
+          flags: MessageFlags.IsComponentsV2,
+        });
+      } else if (interaction.isButton() && interaction.customId === 'dig-equipment') {
+        const stats = resources.userStats[state.userId] || {};
+        const container = buildEquipmentContainer(interaction.user, stats);
+        await interaction.update({
+          components: [container],
+          flags: MessageFlags.IsComponentsV2,
+        });
+      } else if (interaction.isButton() && interaction.customId === 'dig-back') {
+        const stats = resources.userStats[state.userId] || {};
+        const container = buildMainContainer(
+          interaction.user,
+          `${interaction.user}, ready for digging?`,
+          0xffffff,
+        );
+        await interaction.update({
+          components: [container],
+          flags: MessageFlags.IsComponentsV2,
+        });
+      }
+    } catch (error) {
+      if (error.code !== 10062) console.error(error);
+    }
+  });
+}
+
+module.exports = { setup };
+

--- a/command/farmView.js
+++ b/command/farmView.js
@@ -285,7 +285,7 @@ function setup(client, resources) {
       if (!state || interaction.user.id !== state.userId) return;
       const stats = resources.userStats[state.userId] || { inventory: [], farm: {} };
       const seeds = (stats.inventory || []).filter(
-        i => /seed/i.test(i.name) && i.type === 'Material',
+        i => /seed/i.test(i.name) && i.types && i.types.includes('Material'),
       );
       if (seeds.length === 0) {
         await interaction.reply({

--- a/command/hunt.js
+++ b/command/hunt.js
@@ -118,7 +118,14 @@ function articleFor(word) {
   return /^[aeiou]/i.test(word) ? 'an' : 'a';
 }
 
-function buildMainContainer(user, stats, text, color, thumb, disableHunt = false) {
+function buildMainContainer(
+  user,
+  stats,
+  text,
+  color,
+  thumb,
+  disableButtons = false,
+) {
   const select = new StringSelectMenuBuilder()
     .setCustomId('hunt-area')
     .setPlaceholder('Area');
@@ -135,7 +142,6 @@ function buildMainContainer(user, stats, text, color, thumb, disableHunt = false
     .setLabel('hunt')
     .setStyle(ButtonStyle.Danger)
     .setEmoji(ITEMS.HuntingRifleT1.emoji);
-  if (disableHunt) huntBtn.setDisabled(true);
   const statBtn = new ButtonBuilder()
     .setCustomId('hunt-stat')
     .setLabel('Hunt Stat')
@@ -146,6 +152,11 @@ function buildMainContainer(user, stats, text, color, thumb, disableHunt = false
     .setLabel('Equipment')
     .setStyle(ButtonStyle.Secondary)
     .setEmoji('<:SBHuntingequipmentsetting:1410895836644376576>');
+  if (disableButtons) {
+    huntBtn.setDisabled(true);
+    statBtn.setDisabled(true);
+    equipBtn.setDisabled(true);
+  }
   const section = new SectionBuilder();
   if (thumb) {
     section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumb));
@@ -218,8 +229,8 @@ function buildEquipmentContainer(user, stats) {
     .setDisabled(true)
     .setEmoji('<:SBHuntingequipmentsetting:1410895836644376576>');
 
-  const guns = (stats.inventory || []).filter(
-    i => (ITEMS[i.id] || {}).type === 'Gun',
+  const guns = (stats.inventory || []).filter(i =>
+    i.id.startsWith('HuntingRifle'),
   );
   const gunSelect = new StringSelectMenuBuilder()
     .setCustomId('hunt-equip-select')
@@ -246,10 +257,7 @@ function buildEquipmentContainer(user, stats) {
       );
   }
 
-  const bullets = (stats.inventory || []).filter(i => {
-    const it = ITEMS[i.id] || {};
-    return it.type === 'Bullet' || it.id === 'Bullet';
-  });
+  const bullets = (stats.inventory || []).filter(i => i.id === 'Bullet');
   const bulletSelect = new StringSelectMenuBuilder()
     .setCustomId('hunt-bullet-select')
     .setPlaceholder('Bullet');

--- a/command/inventory.js
+++ b/command/inventory.js
@@ -11,7 +11,19 @@ const {
 } = require('discord.js');
 const { normalizeInventory } = require('../utils');
 
-const ITEM_TYPES = ['Consumable', 'Material', 'Misc', 'Tool', 'Accessory', 'Upgrade', 'Weapon', 'Chest', 'All'];
+const ITEM_TYPES = [
+  'Consumable',
+  'Equipment',
+  'Tool',
+  'Container',
+  'Sellable',
+  'Material',
+  'Collectible',
+  'Cosmetic',
+  'Quest',
+  'ADMIN',
+  'All',
+];
 const RARITY_EMOJIS = {
   Common: '<:SBRCommon:1409932856762826862>',
   Rare: '<:SBRRare:1409932954037387324>',
@@ -32,7 +44,9 @@ async function sendInventory(user, send, { userStats, saveData }, state = { page
   const items = stats.inventory || [];
   const totalValue = items.reduce((sum, item) => sum + (item.value || 0) * (item.amount || 0), 0);
   const types = state.types.includes('All') ? ['All'] : state.types;
-  const filtered = types.includes('All') ? items : items.filter(i => types.includes(i.type));
+  const filtered = types.includes('All')
+    ? items
+    : items.filter(i => i.types && i.types.some(t => types.includes(t)));
   const pages = Math.max(1, Math.ceil(filtered.length / 10));
   const page = Math.min(Math.max(state.page, 1), pages);
   const start = (page - 1) * 10;
@@ -45,7 +59,11 @@ async function sendInventory(user, send, { userStats, saveData }, state = { page
     listContent = pageItems
       .map(
         item =>
-          `**${item.emoji} ${item.name}** ═ ${item.amount}\n<:SBreply1:1403665779404050562>Type: ${item.type}\n<:SBreply:1403665761825980456>Rarity: ${RARITY_EMOJIS[item.rarity] || ''} ${item.rarity}`,
+          `**${item.emoji} ${item.name}** ═ ${item.amount}\n<:SBreply1:1403665779404050562>Type: ${
+            (item.types || []).join(', ')
+          }\n<:SBreply:1403665761825980456>Rarity: ${
+            RARITY_EMOJIS[item.rarity] || ''
+          } ${item.rarity}`,
       )
       .join('\n\n');
   }

--- a/command/shop.js
+++ b/command/shop.js
@@ -34,6 +34,7 @@ const SHOP_ITEMS = {
     ITEMS.HarvestScythe,
     ITEMS.BulletBox,
     ITEMS.HuntingRifleT1,
+    ITEMS.Shovel,
   ],
   deluxe: [ITEMS.DiamondBag, ITEMS.DiamondCrate, ITEMS.DiamondChest],
 };

--- a/items.js
+++ b/items.js
@@ -1,4 +1,38 @@
 const { ANIMAL_ITEMS } = require('./animals');
+const XLSX = require('xlsx');
+
+function loadDigItems() {
+  const workbook = XLSX.readFile('Dig item data.xlsx');
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  const items = [];
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (!row || !row[0]) continue;
+    const id = String(row[0]).replace(/\s+/g, '');
+    const types = [row[5], row[6], row[7]]
+      .filter(Boolean)
+      .map(t => String(t).trim())
+      .map(t => t.charAt(0).toUpperCase() + t.slice(1).toLowerCase());
+    items.push({
+      id,
+      name: row[0],
+      emoji: row[8],
+      rarity: row[1],
+      value: Number(row[3]) || 0,
+      useable: false,
+      types,
+      note: '',
+      image: '',
+      price: '',
+      sellPrice: Number(row[4]) || null,
+      chance: Number(row[2]) || 0,
+    });
+  }
+  return items;
+}
+
+const DIG_ITEMS = loadDigItems();
 
 const ITEMS = {
   Padlock: {
@@ -8,7 +42,7 @@ const ITEMS = {
     rarity: 'Common',
     value: 100,
     useable: true,
-    type: 'Consumable',
+    types: ['Consumable', 'Tool'],
     note: '',
     image: 'https://i.ibb.co/bjm9Mbr5/Padlock.png',
     price: 35000,
@@ -21,7 +55,7 @@ const ITEMS = {
     rarity: 'Rare',
     value: 500,
     useable: false,
-    type: 'Consumable',
+    types: ['Consumable', 'Collectible'],
     note: '',
     image: 'https://i.ibb.co/45pFNnY/Seraphic-Heart.png',
     price: 300000,
@@ -34,7 +68,7 @@ const ITEMS = {
     rarity: 'Rare',
     value: 350,
     useable: true,
-    type: 'Consumable',
+    types: ['Consumable', 'Tool'],
     note: '',
     image: 'https://i.ibb.co/239w692Y/Landmine.png',
     price: 200000,
@@ -47,7 +81,7 @@ const ITEMS = {
     rarity: 'Common',
     value: 50,
     useable: false,
-    type: 'Material',
+    types: ['Consumable', 'Material'],
     note: '',
     image: 'https://i.ibb.co/hRpZsFyX/Wheat-seed-package.png',
     price: 10000,
@@ -60,7 +94,7 @@ const ITEMS = {
     rarity: 'Rare',
     value: 500,
     useable: false,
-    type: 'Tool',
+    types: ['Equipment', 'Tool'],
     note: '',
     image: 'https://i.ibb.co/vCjYnjPS/Harvest-scythe.png',
     price: 120000,
@@ -73,7 +107,7 @@ const ITEMS = {
     rarity: 'Rare',
     value: 250,
     useable: false,
-    type: 'Material',
+    types: ['Material', 'Sellable'],
     note: '',
     image: 'https://i.ibb.co/60mfbHqp/Wheat.png',
     price: 0,
@@ -86,7 +120,7 @@ const ITEMS = {
     rarity: 'Common',
     value: 150,
     useable: false,
-    type: 'Tool',
+    types: ['Tool', 'Equipment'],
     note: '',
     image: 'https://i.ibb.co/vv65JBH8/Watering-Can.png',
     price: 70000,
@@ -99,7 +133,7 @@ const ITEMS = {
     rarity: 'Prismatic',
     value: 7500,
     useable: true,
-    type: 'Chest',
+    types: ['Container', 'Consumable', 'Collectible'],
     note: 'Give 10k Diamonds',
     image: 'https://i.ibb.co/fYXHjr13/Bag-of-Diamond.png',
     price: 100,
@@ -112,7 +146,7 @@ const ITEMS = {
     rarity: 'Prismatic',
     value: 8000,
     useable: true,
-    type: 'Chest',
+    types: ['Container', 'Consumable', 'Collectible'],
     note: 'Give 135k Diamonds',
     image: 'https://i.ibb.co/5xLZZ25K/Crate-of-Diamond.png',
     price: 900,
@@ -125,7 +159,7 @@ const ITEMS = {
     rarity: 'Prismatic',
     value: 9000,
     useable: true,
-    type: 'Chest',
+    types: ['Container', 'Consumable', 'Collectible'],
     note: 'Give 980k Diamonds',
     image: 'https://i.ibb.co/4nJR1ZnC/Chest-of-Diamond.png',
     price: 4900,
@@ -138,7 +172,7 @@ const ITEMS = {
     rarity: 'Secret',
     value: 0,
     useable: true,
-    type: 'Weapon',
+    types: ['Tool', 'Collectible', 'Cosmetic', 'ADMIN'],
     note: 'Admin only item',
     image: '',
     price: 0,
@@ -151,7 +185,7 @@ const ITEMS = {
     rarity: 'Common',
     value: 200,
     useable: false,
-    type: 'Weapon',
+    types: ['Equipment', 'Tool'],
     note: '',
     image: 'https://i.ibb.co/3mbdZLv3/rifle.png',
     price: 50000,
@@ -164,10 +198,23 @@ const ITEMS = {
     rarity: 'Common',
     value: 100,
     useable: true,
-    type: 'Consumable',
+    types: ['Container', 'Material', 'Consumable'],
     note: 'A bullet box gives 6 bullets.',
     image: 'https://i.ibb.co/TM3NStHG/Bullet-Box.png',
     price: 30000,
+    sellPrice: null,
+  },
+  Shovel: {
+    id: 'Shovel',
+    name: 'Shovel',
+    emoji: '<:ITShovel:1412067842303594567>',
+    rarity: 'Common',
+    value: 225,
+    useable: true,
+    types: ['Tool', 'Equipment'],
+    note: '',
+    image: 'https://i.ibb.co/PGDZzsG3/Shovel.png',
+    price: 50000,
     sellPrice: null,
   },
   Bullet: {
@@ -177,13 +224,14 @@ const ITEMS = {
     rarity: 'Common',
     value: 20,
     useable: false,
-    type: 'Consumable',
+    types: ['Consumable', 'Material'],
     note: '',
     image: '',
     price: 0,
     sellPrice: null,
   },
+  ...Object.fromEntries(DIG_ITEMS.map(it => [it.id, it])),
   ...ANIMAL_ITEMS,
 };
 
-module.exports = { ITEMS };
+module.exports = { ITEMS, DIG_ITEMS };

--- a/shopMediaDeluxe.js
+++ b/shopMediaDeluxe.js
@@ -307,7 +307,7 @@ async function deluxeCard(ctx, x, y, w, h, item = {}, coinImg, priceFontSize) {
 
   // Price Row
   const rowY = gy + gh - priceSectionH / 2;
-  const coinSize = 25;
+  const coinSize = 40;
   const coinR = coinSize / 2;
     const coinX = gx + contentPad + coinR;
     if (coinImg) {


### PR DESCRIPTION
## Summary
- Expand deluxe shop rendering with larger coin icon
- Revamp item type system and add Shovel plus dig loot from spreadsheet
- Introduce /dig command and disable hunt UI while resolving

## Testing
- `find . -path ./node_modules -prune -o -name '*.js' -print0 | xargs -0 -n1 node --check`


------
https://chatgpt.com/codex/tasks/task_e_68b70ad4f0308321a8449e4d32f7521a