### PR TITLE
Add centralized error reporting

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -27,6 +27,7 @@ const huntCommand = require('./command/hunt');
 const digCommand = require('./command/dig');
 const { ITEMS } = require('./items');
 const { setSafeTimeout } = require('./utils');
+const { setupErrorHandling } = require('./errorHandler');
 
 const DATA_FILE = 'user_data.json';
 let userStats = {};
@@ -177,6 +178,7 @@ const client = new Client({
   intents:[GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildVoiceStates]
 });
 client.setMaxListeners(20);
+setupErrorHandling(client, '1383481711651721307');
 
 // Wrap interactionCreate listeners so banned interactions don't trigger other handlers
 const originalOn = client.on.bind(client);

--- a/errorHandler.js
+++ b/errorHandler.js
@@ -1,0 +1,21 @@
+const sendError = async (client, channelId, title, error) => {
+  const channel = await client.channels.fetch(channelId).catch(() => null);
+  if (!channel) return;
+  const content = `**${title}**\n\n\`\`\`${error && error.stack ? error.stack : String(error)}\`\`\``;
+  await channel.send({ content }).catch(() => {});
+};
+
+function setupErrorHandling(client, channelId) {
+  process.on('unhandledRejection', error => {
+    sendError(client, channelId, 'Unhandled Rejection', error);
+  });
+  process.on('uncaughtException', async error => {
+    await sendError(client, channelId, 'Uncaught Exception', error);
+    process.exit(1);
+  });
+  client.on('error', error => {
+    sendError(client, channelId, 'Client Error', error);
+  });
+}
+
+module.exports = { setupErrorHandling };


### PR DESCRIPTION
## Summary
- add errorHandler module to report full stack traces to channel `1383481711651721307`
- initialize error reporting in bot setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b712a2d40883219a8bcd4b091ab68a