### PR TITLE
feat: add prefix support for dig command

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -373,6 +373,12 @@ client.on('messageCreate', async message => {
         message.channel.send.bind(message.channel),
         resources,
       );
+    } else if (lowerAfter === 'dig') {
+      await digCommand.sendDig(
+        message.author,
+        message.channel.send.bind(message.channel),
+        resources,
+      );
     } else if (lowerAfter === 'shop view') {
       await shopCommand.sendShop(
         message.author,


### PR DESCRIPTION
## Summary
- allow dig command to be executed via `a.dig` prefix
- refactor dig slash command to reuse shared `sendDig` helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7c34a9db083219698fa4d250ada36