### PR TITLE
Add dig equipment selection and backpack cap

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -78,4 +78,17 @@ function setSafeTimeout(fn, delay) {
   return setTimeout(() => setSafeTimeout(fn, delay - MAX_TIMEOUT), MAX_TIMEOUT);
 }
 
-module.exports = { formatNumber, parseAmount, normalizeInventory, setSafeTimeout };
+const MAX_ITEMS = 500;
+
+function getInventoryCount(stats) {
+  return (stats.inventory || []).reduce((sum, i) => sum + (i.amount || 0), 0);
+}
+
+module.exports = {
+  formatNumber,
+  parseAmount,
+  normalizeInventory,
+  setSafeTimeout,
+  getInventoryCount,
+  MAX_ITEMS,
+};


### PR DESCRIPTION
## Summary
- Add global backpack limit with helper to count inventory items
- Show detailed stats for hunting and digging including discoveries
- Support tool selection and 30s cooldown for digging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9328b3738832196a542596d6660f2