### PR TITLE
Increase listener limit and fix hunt section accessory

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -177,7 +177,7 @@ const resources = { userStats, userCardSettings, commandBans, saveData, xpNeeded
 const client = new Client({
   intents:[GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent, GatewayIntentBits.GuildVoiceStates]
 });
-client.setMaxListeners(20);
+client.setMaxListeners(50);
 setupErrorHandling(client, '1383481711651721307');
 
 // Wrap interactionCreate listeners so banned interactions don't trigger other handlers

--- a/command/hunt.js
+++ b/command/hunt.js
@@ -157,11 +157,11 @@ function buildMainContainer(
     statBtn.setDisabled(true);
     equipBtn.setDisabled(true);
   }
-  const section = new SectionBuilder();
-  if (thumb) {
-    section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumb));
-  }
-  section.addTextDisplayComponents(new TextDisplayBuilder().setContent(text));
+  const section = new SectionBuilder()
+    .setThumbnailAccessory(
+      new ThumbnailBuilder().setURL(thumb || user.displayAvatarURL()),
+    )
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(text));
   return new ContainerBuilder()
     .setAccentColor(color)
     .addSectionComponents(section)


### PR DESCRIPTION
## Summary
- raise Discord client max listeners to prevent `MaxListenersExceededWarning`
- ensure hunt command section always includes a thumbnail accessory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93da8efb88321b71284e3b73a7371