### PR TITLE
feat: enforce inventory capacity

### DIFF
--- a/command/dig.js
+++ b/command/dig.js
@@ -232,7 +232,8 @@ async function sendDig(user, send, resources, fetchReply) {
   return message;
 }
 
-async function handleDig(message, user, resources, stats) {
+async function handleDig(interaction, resources, stats) {
+  const { message, user } = interaction;
   const success = Math.random() < 0.5;
   const cooldown = Date.now() + 30000;
   stats.dig_cd_until = cooldown;
@@ -260,6 +261,14 @@ async function handleDig(message, user, resources, stats) {
         extra = `\n-# You also found **${item.name} ${item.emoji}** while digging! ${
           RARITY_EMOJIS[item.rarity] || ''
         }${full ? '\n-# Your backpack is full!' : ''}`;
+        if (full) {
+          interaction
+            .followUp({
+              content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+              flags: MessageFlags.Ephemeral,
+            })
+            .catch(() => {});
+        }
       }
     }
     text = `${user}, you have digged up **${amount} Coins ${COIN_EMOJI}!**${extra}\n-# You can dig again <t:${Math.floor(
@@ -356,7 +365,7 @@ function setup(client, resources) {
           flags: MessageFlags.IsComponentsV2,
         });
         setTimeout(() => {
-          handleDig(interaction.message, interaction.user, resources, stats);
+          handleDig(interaction, resources, stats);
         }, 3000);
       } else if (interaction.isButton() && interaction.customId === 'dig-stat') {
         const stats = resources.userStats[state.userId] || {};

--- a/command/hunt.js
+++ b/command/hunt.js
@@ -357,7 +357,8 @@ async function sendHunt(user, send, resources, fetchReply) {
   return message;
 }
 
-async function handleHunt(message, user, resources, stats) {
+async function handleHunt(interaction, resources, stats) {
+  const { message, user } = interaction;
   const areaObj = getArea(stats.hunt_area);
   if (!areaObj) return;
   normalizeInventory(stats);
@@ -406,6 +407,14 @@ async function handleHunt(message, user, resources, stats) {
     } ${RARITY_EMOJIS[animal.rarity] || ''}${full ? '\n-# Your backpack is full!' : ''}\n-# You can hunt again <t:${Math.floor(
       cooldown / 1000,
     )}:R>`;
+    if (full) {
+      interaction
+        .followUp({
+          content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+          flags: MessageFlags.Ephemeral,
+        })
+        .catch(() => {});
+    }
   } else if (roll < 0.9) {
     stats.hunt_fail = (stats.hunt_fail || 0) + 1;
     const fail = FAIL_MESSAGES[Math.floor(Math.random() * FAIL_MESSAGES.length)];
@@ -521,7 +530,7 @@ function setup(client, resources) {
           flags: MessageFlags.IsComponentsV2,
         });
         setTimeout(() => {
-          handleHunt(interaction.message, interaction.user, resources, stats);
+          handleHunt(interaction, resources, stats);
         }, 3000);
       } else if (
         interaction.isButton() &&

--- a/command/inventory.js
+++ b/command/inventory.js
@@ -9,7 +9,7 @@ const {
   ActionRowBuilder,
   StringSelectMenuBuilder,
 } = require('discord.js');
-const { normalizeInventory } = require('../utils');
+const { normalizeInventory, getInventoryCount, MAX_ITEMS } = require('../utils');
 
 const ITEM_TYPES = [
   'Consumable',
@@ -43,6 +43,7 @@ async function sendInventory(user, send, { userStats, saveData }, state = { page
   if (saveData) saveData();
   const items = stats.inventory || [];
   const totalValue = items.reduce((sum, item) => sum + (item.value || 0) * (item.amount || 0), 0);
+  const count = getInventoryCount(stats);
   const types = state.types.includes('All') ? ['All'] : state.types;
   const filtered = types.includes('All')
     ? items
@@ -72,7 +73,7 @@ async function sendInventory(user, send, { userStats, saveData }, state = { page
     .setThumbnailAccessory(new ThumbnailBuilder().setURL(user.displayAvatarURL()))
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        `### ${user.username}'s Inventory\n* <:SBstars:1404723253200552009> Total Inventory Value: ${totalValue}`,
+        `### ${user.username}'s Inventory\n* <:SBstars:1404723253200552009> Total Inventory Value: ${totalValue}\n* Capacity: ${count} / ${MAX_ITEMS}`,
       ),
     );
 

--- a/command/shop.js
+++ b/command/shop.js
@@ -21,7 +21,7 @@ const {
 const { renderShopMedia } = require('../shopMedia');
 const { renderDeluxeMedia } = require('../shopMediaDeluxe');
 const { ITEMS } = require('../items');
-const { normalizeInventory } = require('../utils');
+const { normalizeInventory, getInventoryCount, MAX_ITEMS } = require('../utils');
 
 // Currently coin and deluxe shops with no items
 const SHOP_ITEMS = {
@@ -396,6 +396,25 @@ function setup(client, resources) {
             ],
             flags: MessageFlags.IsComponentsV2,
           });
+          return;
+        }
+        if (getInventoryCount(stats) + amount > MAX_ITEMS) {
+          await interaction.update({
+            components: [
+              new ActionRowBuilder().addComponents(
+                new TextDisplayBuilder().setContent(
+                  '<:SBWarning:1404101025849147432> Your backpack is full!',
+                ),
+              ),
+            ],
+            flags: MessageFlags.IsComponentsV2,
+          });
+          await interaction
+            .followUp({
+              content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+              flags: MessageFlags.Ephemeral,
+            })
+            .catch(() => {});
           return;
         }
         stats[currency] = (stats[currency] || 0) - total;


### PR DESCRIPTION
## Summary
- show inventory capacity in the inventory command
- block purchases when backpack is full
- warn and skip rewards when actions occur with a full backpack

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b942b876a883219b95ae58fd62d9fa