### PR TITLE
Send direct inventory full warning

### DIFF
--- a/command/dig.js
+++ b/command/dig.js
@@ -260,11 +260,11 @@ async function handleDig(interaction, resources, stats) {
         }
         extra = `\n-# You also found **${item.name} ${item.emoji}** while digging! ${
           RARITY_EMOJIS[item.rarity] || ''
-        }${full ? '\n-# Your backpack is full!' : ''}`;
+        }`;
         if (full) {
           interaction
             .followUp({
-              content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+              content: `${user}, your inventory is full. Any items you earned will not be added to your inventory!`,
               flags: MessageFlags.Ephemeral,
             })
             .catch(() => {});

--- a/command/farmView.js
+++ b/command/farmView.js
@@ -461,18 +461,14 @@ function setup(client, resources) {
       state.selected = [];
       await updateFarmMessage(state, interaction.user, stats, resources);
       let content = '';
-      if (full) {
-        content = '<:SBWarning:1404101025849147432> Your backpack is full!';
-      } else {
-        if (harvested > 0)
-          content += `You harvested ${harvested} ${ITEMS.Wheat.emoji} ${ITEMS.Wheat.name}.`;
-        if (returnedSeeds > 0)
-          content += `${content ? '\n' : ''}You received ${returnedSeeds} ${ITEMS.WheatSeed.emoji} ${ITEMS.WheatSeed.name}${
-            returnedSeeds > 1 ? 's' : ''
-          }.`;
-        if (deadNote) content += `\n-# Your wheat died...`;
-        if (!content) content = 'Nothing harvested.';
-      }
+      if (harvested > 0)
+        content += `You harvested ${harvested} ${ITEMS.Wheat.emoji} ${ITEMS.Wheat.name}.`;
+      if (returnedSeeds > 0)
+        content += `${content ? '\n' : ''}You received ${returnedSeeds} ${ITEMS.WheatSeed.emoji} ${ITEMS.WheatSeed.name}${
+          returnedSeeds > 1 ? 's' : ''
+        }.`;
+      if (deadNote) content += `\n-# Your wheat died...`;
+      if (!content) content = 'Nothing harvested.';
       const container = new ContainerBuilder()
         .setAccentColor(0xffffff)
         .addTextDisplayComponents(new TextDisplayBuilder().setContent(content));
@@ -483,7 +479,7 @@ function setup(client, resources) {
       if (full) {
         await interaction
           .followUp({
-            content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+            content: `${interaction.user}, your inventory is full. Any items you earned will not be added to your inventory!`,
             flags: MessageFlags.Ephemeral,
           })
           .catch(() => {});

--- a/command/hunt.js
+++ b/command/hunt.js
@@ -404,13 +404,13 @@ async function handleHunt(interaction, resources, stats) {
     color = RARITY_COLORS[animal.rarity] || 0xffffff;
     text = `${user}, you have hunted ${art} **${animal.name} ${animal.emoji}**!\n* Rarity: ${
       animal.rarity
-    } ${RARITY_EMOJIS[animal.rarity] || ''}${full ? '\n-# Your backpack is full!' : ''}\n-# You can hunt again <t:${Math.floor(
+    } ${RARITY_EMOJIS[animal.rarity] || ''}\n-# You can hunt again <t:${Math.floor(
       cooldown / 1000,
     )}:R>`;
     if (full) {
       interaction
         .followUp({
-          content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+          content: `${user}, your inventory is full. Any items you earned will not be added to your inventory!`,
           flags: MessageFlags.Ephemeral,
         })
         .catch(() => {});

--- a/command/shop.js
+++ b/command/shop.js
@@ -399,19 +399,12 @@ function setup(client, resources) {
           return;
         }
         if (getInventoryCount(stats) + amount > MAX_ITEMS) {
-          await interaction.update({
-            components: [
-              new ActionRowBuilder().addComponents(
-                new TextDisplayBuilder().setContent(
-                  '<:SBWarning:1404101025849147432> Your backpack is full!',
-                ),
-              ),
-            ],
-            flags: MessageFlags.IsComponentsV2,
-          });
+          await interaction
+            .deferUpdate({ flags: MessageFlags.IsComponentsV2 })
+            .catch(() => {});
           await interaction
             .followUp({
-              content: '<:SBWarning:1404101025849147432> Your backpack is full!',
+              content: `${interaction.user}, your inventory is full. Any items you earned will not be added to your inventory!`,
               flags: MessageFlags.Ephemeral,
             })
             .catch(() => {});


### PR DESCRIPTION
## Summary
- Send dedicated inventory full warnings in dig, hunt, farm harvest, and shop purchase commands
- Remove inline "backpack is full" notices from primary responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b94f3f65548321833a824ebeb9b0b6