### PR TITLE
Limit hunt stats to three section components

### DIFF
--- a/command/hunt.js
+++ b/command/hunt.js
@@ -215,16 +215,11 @@ function buildStatContainer(user, stats) {
         }`,
       ),
       new TextDisplayBuilder().setContent(
-        `Hunt amount: ${stats.hunt_total || 0}`,
-      ),
-      new TextDisplayBuilder().setContent(
-        `-# Success: ${stats.hunt_success || 0}`,
-      ),
-      new TextDisplayBuilder().setContent(
-        `-# failed: ${stats.hunt_fail || 0}`,
-      ),
-      new TextDisplayBuilder().setContent(
-        `-# died: ${stats.hunt_die || 0}`,
+        `Hunt amount: ${stats.hunt_total || 0}\n-# Success: ${
+          stats.hunt_success || 0
+        }\n-# failed: ${stats.hunt_fail || 0}\n-# died: ${
+          stats.hunt_die || 0
+        }`,
       ),
       new TextDisplayBuilder().setContent(
         `Item discovered: ${discovered} / ${totalAnimals}`,


### PR DESCRIPTION
## Summary
- Consolidate hunt stats into fewer text displays to respect SectionBuilder component limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9a3d4878083219053526f337b9119