### PR TITLE
Add separator before team participation message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -283,24 +283,31 @@ client.on = function(event, listener) {
       try {
         const channel = await client.channels.fetch(cshChannelId);
         if (channel) {
-          const content = [
+          const introContent = [
             '## Holly Jolly Hunt 2025',
             '* Something’s afoot at the North Pole… 🐾❄️ On December 1st 2025 📅, report to Ć̵̘R̴̞͌E̶̞͉͛A̷̘̅̌T̸̺̔O̶̤͌̕R̴̨̯̓͑ for a trail of riddles 🧩, secret codes 🔐, and festive red herrings🎄. Crack the case🕵️‍♂️, outsmart rival teams 🧠, and uncover Santa’s missing cargo 🛷 before the clock strikes tinsel.**.',
             '-# This is bot scavenger hunt, so all puzzle will be inside bot features and it will not be held outside.',
-            'You will participate in a team, max 2 per team. If not enough you will be disqualified!',
-            `-# Team registration start <t:${cshTimestamp}:R>`
           ].join('\n');
+
           const section = new SectionBuilder()
             .setThumbnailAccessory(
               new ThumbnailBuilder().setURL(
                 'https://i.ibb.co/rfLBNZJC/45da76a2-9fe3-4b98-96cb-614185f87d41.png',
               ),
             )
-            .addTextDisplayComponents(new TextDisplayBuilder().setContent(content));
+            .addTextDisplayComponents(
+              new TextDisplayBuilder().setContent(introContent),
+            );
+
+          const warningContent = new TextDisplayBuilder().setContent(
+            `You will participate in a team, max 2 per team. If not enough you will be disqualified!\n-# Team registration start <t:${cshTimestamp}:R>`,
+          );
 
           const container = new ContainerBuilder()
             .setAccentColor(0x00ffff)
             .addSectionComponents(section)
+            .addSeparatorComponents(new SeparatorBuilder())
+            .addTextDisplayComponents(warningContent)
             .addActionRowComponents(
               new ActionRowBuilder().addComponents(
                 new StringSelectMenuBuilder()


### PR DESCRIPTION
## Summary
- replace textual delimiter with Discord v2 separator component before the team participation warning in the CSH countdown message

## Testing
- `npm test` *(fails: scans entire tree including node_modules; process terminated)*
- `find . -name '*.js' -not -path './node_modules/*' -print0 | xargs -0 -n1 node --check`


------
https://chatgpt.com/codex/tasks/task_e_68bafea7ecac8321b8238831b6dd2843