### PR TITLE
Use single thumbnail for CSH message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -304,11 +304,6 @@ client.on = function(event, listener) {
             )
             .addTextDisplayComponents(new TextDisplayBuilder().setContent(message1));
           const section2 = new SectionBuilder()
-            .setThumbnailAccessory(
-              new ThumbnailBuilder().setURL(
-                'https://i.ibb.co/rfLBNZJC/45da76a2-9fe3-4b98-96cb-614185f87d41.png',
-              ),
-            )
             .addTextDisplayComponents(
               new TextDisplayBuilder().setContent(message2),
             );


### PR DESCRIPTION
## Summary
- avoid multiple thumbnails in CSH message by removing duplicate section image

## Testing
- `npm test` *(fails: script traverses node_modules indefinitely)*

------
https://chatgpt.com/codex/tasks/task_e_68bb11a0301483218c6cfea17ee798f7