### PR TITLE
Resend CSH message if previous message is missing

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -326,7 +326,13 @@ client.on = function(event, listener) {
                   ),
               ),
             );
-          if (!cshMessageId) {
+          let existing = null;
+          if (cshMessageId) {
+            existing = await channel.messages
+              .fetch(cshMessageId)
+              .catch(() => null);
+          }
+          if (!existing) {
             const sent = await channel.send({ components: [container], flags: MessageFlags.IsComponentsV2 });
             cshMessageId = sent.id;
             saveData();


### PR DESCRIPTION
## Summary
- Ensure CSH countdown message is resent when stored message ID no longer exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbe26bc9388321b56bf0dae71ccd6f