### PR TITLE
chore: remove placeholder button from CSH message

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -306,13 +306,6 @@ client.on = function(event, listener) {
           const section2 = new SectionBuilder()
             .addTextDisplayComponents(
               new TextDisplayBuilder().setContent(message2),
-            )
-            .setButtonAccessory(
-              new ButtonBuilder()
-                .setCustomId('csh-placeholder')
-                .setLabel('Team registration time not yet')
-                .setStyle(ButtonStyle.Secondary)
-                .setDisabled(true),
             );
 
           const container = new ContainerBuilder()


### PR DESCRIPTION
## Summary
- remove unused placeholder button from CSH countdown message

## Testing
- `npm test` *(fails: command hung scanning node_modules)*
- `node --check bot.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbe69a05408321a6664143d23357ed