### PR TITLE
Fix empty SectionBuilder in cosmetic command

### DIFF
--- a/command/myCosmetic.js
+++ b/command/myCosmetic.js
@@ -80,12 +80,15 @@ function buildContainer(user, stats, state = {}) {
   return new ContainerBuilder()
     .setAccentColor(0xffffff)
     .addSectionComponents(
-      new SectionBuilder().setThumbnailAccessory(
-        new ThumbnailBuilder().setURL(user.displayAvatarURL()),
-      ),
-    )
-    .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(`## Equipped cosmetics:\n${equippedList}`),
+      new SectionBuilder()
+        .setThumbnailAccessory(
+          new ThumbnailBuilder().setURL(user.displayAvatarURL()),
+        )
+        .addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            `## Equipped cosmetics:\n${equippedList}`,
+          ),
+        ),
     )
     .addSeparatorComponents(new SeparatorBuilder())
     .addTextDisplayComponents(


### PR DESCRIPTION
## Summary
- ensure the cosmetic section includes a text display so the SectionBuilder is never empty

## Testing
- `npm test` *(fails: command halted due to repository size)*
- `node --check command/myCosmetic.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc21f10c088321b9cd101a5c2d081b