### PR TITLE
feat: add chat mastery system

### DIFF
--- a/command/mastery.js
+++ b/command/mastery.js
@@ -1,0 +1,128 @@
+const {
+  SlashCommandBuilder,
+  MessageFlags,
+  ContainerBuilder,
+  TextDisplayBuilder,
+  SeparatorBuilder,
+  ActionRowBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
+  SectionBuilder,
+  ThumbnailBuilder,
+} = require('discord.js');
+
+const CHAT_THUMB = 'https://i.ibb.co/6RGR6jYf/Chat-badge-normal.png';
+const CHAT_THUMB_MAX = 'https://ibb.co/jFHRrQ4';
+
+function buildBar(current, needed) {
+  if (needed <= 0) return '░'.repeat(20);
+  const filled = Math.min(20, Math.round((current / needed) * 20));
+  return '▓'.repeat(filled) + '░'.repeat(20 - filled);
+}
+
+function buildPerks(level) {
+  const perks = [
+    { level: 10, text: '+50% more coin from chat and voice chat', initial:'<:SBE1:1414145519462387752>', current:'<:SBF1:1414145589465190501>', done:'<:SBF4:1414145601737588839>' },
+    { level: 20, text: 'every 1h in voice award some diamonds', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 30, text: '+100% more coin from chat and voice chat', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 40, text: 'every 100 message you send give some diamonds', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 50, text: '+150% more coin from chat and voice chat', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 60, text: 'Small chance to earn item when chatting and voice chatting', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 70, text: 'Every 1 chat level give 10% more coin earn from chat and voice chat', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 80, text: '+200% more coin from chat and voice chat', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 90, text: 'Everytime you leveling up award some diamonds.', initial:'<:SBE2:1414145551087177839>', current:'<:SBF2:1414145565436149790>', done:'<:SBF:1414145617512366120>' },
+    { level: 100, text: 'Unlock ability to get secret item in chat and voice chat', initial:'<:SBE3:1414145536696516698>', current:'<:SBF3:1414145576878080132>', done:'<:SBF3:1414145576878080132>' },
+  ];
+  let unlockedIndex = -1;
+  for (let i = 0; i < perks.length; i++) {
+    if (level >= perks[i].level) unlockedIndex = i;
+  }
+  const lines = perks.map((p, idx) => {
+    let icon = p.initial;
+    let text = p.text;
+    if (idx < unlockedIndex) {
+      icon = p.done;
+      text = `**${text}**`;
+    } else if (idx === unlockedIndex && level >= p.level) {
+      icon = p.current;
+      text = `**${text}**`;
+    }
+    return `-# ${icon} ${text}`;
+  });
+  return lines.join('\n');
+}
+
+function buildResponse(user, stats, chatMasteryXpNeeded) {
+  const level = stats.chat_mastery_level || 0;
+  const xp = stats.chat_mastery_xp || 0;
+  const next = level >= 100 ? 0 : chatMasteryXpNeeded(level + 1);
+  const bar = buildBar(xp, next);
+  const header = new SectionBuilder().setText(`## Chat Mastery - Level ${level}\n-# ${bar} [${xp} / ${next || 'MAX'}]`);
+  const perks = buildPerks(level);
+  const container = new ContainerBuilder().setAccentColor(level >= 100 ? 0xffff00 : 0xffffff);
+  container.addSectionComponents(header);
+  if (level >= 100) {
+    container.addThumbnailComponents(new ThumbnailBuilder().setURL(CHAT_THUMB_MAX));
+  } else {
+    container.addThumbnailComponents(new ThumbnailBuilder().setURL(CHAT_THUMB));
+  }
+  container
+    .addSeparatorComponents(new SeparatorBuilder())
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent('* Mastery perks, every 10 levels unlock 1 perk.'))
+    .addTextDisplayComponents(new TextDisplayBuilder().setContent(perks));
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId('mastery-select')
+    .setPlaceholder('Mastery')
+    .addOptions(
+      new StringSelectMenuOptionBuilder()
+        .setLabel('Chat Mastery')
+        .setValue('chat')
+        .setEmoji('<:SBMChat:1414143736488788089>')
+        .setDefault(true)
+    );
+  container.addActionRowComponents(new ActionRowBuilder().addComponents(select));
+  return container;
+}
+
+function setup(client, resources) {
+  const command = new SlashCommandBuilder().setName('mastery').setDescription('Show your mastery levels');
+  client.application.commands.create(command);
+
+  client.on('interactionCreate', async interaction => {
+    try {
+      if (!interaction.isChatInputCommand() || interaction.commandName !== 'mastery') return;
+      const select = new StringSelectMenuBuilder()
+        .setCustomId('mastery-select')
+        .setPlaceholder('Mastery')
+        .addOptions(
+          new StringSelectMenuOptionBuilder()
+            .setLabel('Chat Mastery')
+            .setValue('chat')
+            .setEmoji('<:SBMChat:1414143736488788089>')
+        );
+      const container = new ContainerBuilder()
+        .setAccentColor(0xffffff)
+        .addTextDisplayComponents(new TextDisplayBuilder().setContent(`${interaction.user}, select a mastery to check the level and perks!`))
+        .addSeparatorComponents(new SeparatorBuilder())
+        .addActionRowComponents(new ActionRowBuilder().addComponents(select));
+      await interaction.reply({ components: [container], flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral });
+    } catch (error) {
+      if (error.code !== 10062) console.error(error);
+    }
+  });
+
+  client.on('interactionCreate', async interaction => {
+    try {
+      if (!interaction.isStringSelectMenu() || interaction.customId !== 'mastery-select') return;
+      if (interaction.values[0] !== 'chat') return;
+      const stats = resources.userStats[interaction.user.id] || {};
+      const container = buildResponse(interaction.user, stats, resources.chatMasteryXpNeeded);
+      await interaction.update({ components: [container], flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral });
+    } catch (error) {
+      if (error.code !== 10062) console.error(error);
+    }
+  });
+}
+
+module.exports = { setup };

--- a/utils.js
+++ b/utils.js
@@ -155,10 +155,18 @@ function useDurableItem(interaction, user, stats, itemId) {
 
 function applyCoinBoost(stats, amount) {
   const slots = (stats && stats.cosmeticSlots) || [];
-  let boost = 0;
-  if (slots.includes('ArcsOfResurgence')) boost += 7.77;
-  if (slots.includes('GoldRing')) boost += 0.1;
-  return Math.floor(amount + amount * boost);
+  let percent = 0;
+  if (slots.includes('ArcsOfResurgence')) percent += 7.77;
+  if (slots.includes('GoldRing')) percent += 0.1;
+  if (stats && stats.chat_mastery_level >= 70) {
+    percent += (stats.level || 0) * 0.1;
+  }
+  let perk = 1;
+  if (stats && stats.chat_mastery_level >= 10) perk += 0.5;
+  if (stats && stats.chat_mastery_level >= 30) perk += 1.0;
+  if (stats && stats.chat_mastery_level >= 50) perk += 1.5;
+  if (stats && stats.chat_mastery_level >= 80) perk += 2.0;
+  return Math.floor(perk * (amount + amount * percent));
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- track chat mastery XP alongside regular XP with scaling levels and perks
- add `/mastery` command to view Chat Mastery progress and perk list
- award voice and message activity with mastery XP, coins, diamonds, and occasional items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd377b999c83218a20a5625cb891ba