### PR TITLE
Fix hunt and dig component layouts

### DIFF
--- a/command/dig.js
+++ b/command/dig.js
@@ -4,7 +4,6 @@ const {
   ContainerBuilder,
   SectionBuilder,
   ThumbnailBuilder,
-  SeparatorBuilder,
   TextDisplayBuilder,
   ActionRowBuilder,
   ButtonBuilder,
@@ -109,7 +108,6 @@ function buildMainContainer(user, text, color, disable = false) {
   return new ContainerBuilder()
     .setAccentColor(color)
     .addSectionComponents(section)
-    .addSeparatorComponents(new SeparatorBuilder())
     .addActionRowComponents(
       new ActionRowBuilder().addComponents(digBtn, statBtn, equipBtn),
     );
@@ -221,9 +219,7 @@ function buildEquipmentContainer(user, stats) {
   return new ContainerBuilder()
     .setAccentColor(0xffffff)
     .addSectionComponents(section)
-    .addSeparatorComponents(new SeparatorBuilder())
     .addActionRowComponents(new ActionRowBuilder().addComponents(toolSelect))
-    .addSeparatorComponents(new SeparatorBuilder())
     .addActionRowComponents(
       new ActionRowBuilder().addComponents(backBtn, statBtn, equipBtn),
     );


### PR DESCRIPTION
## Summary
- update hunt containers to respect the component v2 three-element limit and split the equipment view into two containers
- adjust the Master Zoologist reward message to use separate sections instead of separators
- remove separators from dig command containers to comply with the component limit

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e292b0fab883259c4700620e8fe45b