### PR TITLE
Fix component emoji resolution for non-custom emoji

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -108,7 +108,9 @@ function resolveComponentEmoji(emoji) {
   if (!emoji) return emoji;
   if (typeof emoji !== 'string') return emoji;
   const match = emoji.match(/^<(?:(a):)?([a-zA-Z0-9_]+):(\d+)>$/);
-  if (!match) return emoji;
+  if (!match) {
+    return { name: emoji };
+  }
   const [, animatedFlag, name, id] = match;
   return {
     id,


### PR DESCRIPTION
## Summary
- convert plain emoji strings into emoji objects before applying them to component builders to satisfy discord.js validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e29c13e0188325b587b64aaef2d89b