### PR TITLE
Fix component emoji resolution

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -109,12 +109,11 @@ function resolveComponentEmoji(emoji) {
   if (typeof emoji !== 'string') return emoji;
   const match = emoji.match(/^<(?:(a):)?([a-zA-Z0-9_]+):(\d+)>$/);
   if (!match) {
-    return { name: emoji };
+    return emoji;
   }
-  const [, animatedFlag, name, id] = match;
+  const [, animatedFlag, , id] = match;
   return {
     id,
-    name,
     animated: Boolean(animatedFlag),
   };
 }


### PR DESCRIPTION
## Summary
- adjust emoji resolution helper to return only the raw unicode for standard emoji
- send only the id for custom emojis so component payloads avoid invalid emoji names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e29debc310832598b5250412725ffc