### PR TITLE
Fix component emoji payload for custom emoji

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -110,10 +110,9 @@ function resolveComponentEmoji(emoji) {
   const trimmed = emoji.trim();
   const match = trimmed.match(/^<(?:(a):)?([a-zA-Z0-9_]+):(\d+)>$/);
   if (match) {
-    const [, animatedFlag, name, id] = match;
+    const [, animatedFlag, , id] = match;
     return {
       id,
-      name,
       animated: Boolean(animatedFlag),
     };
   }


### PR DESCRIPTION
## Summary
- stop sending the emoji name with custom component emoji payloads
- rely on the emoji id and animation flag to avoid Discord validation errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a097e3e4832596dd48a0bfb82f3a