### PR TITLE
Fix custom emoji parsing for component builders

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -108,13 +108,13 @@ function resolveComponentEmoji(emoji) {
   if (!emoji) return emoji;
   if (typeof emoji !== 'string') return emoji;
   const trimmed = emoji.trim();
-  const match = trimmed.match(/^<(?:(a):)?([a-zA-Z0-9_]+):(\d+)>$/);
+  const match = trimmed.match(/^<(a?):([a-zA-Z0-9_]+):(\d+)>$/);
   if (match) {
     const [, animatedFlag, name, id] = match;
     return {
       id,
       name,
-      animated: Boolean(animatedFlag),
+      animated: animatedFlag === 'a',
     };
   }
   return { name: trimmed };


### PR DESCRIPTION
## Summary
- correct the regex used to parse custom emojis so static emojis resolve correctly
- ensure component builders receive valid emoji payloads when building hunt menus

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a2ba5e888325ae3d6a668726996f