### PR TITLE
Fix hunt equipment builder validation and regroup shop buttons

### DIFF
--- a/command/hunt.js
+++ b/command/hunt.js
@@ -362,7 +362,7 @@ function buildEquipmentContainer(user, stats) {
       );
   }
 
-  const section = new SectionBuilder()
+  const equipmentSection = new SectionBuilder()
     .setThumbnailAccessory(
       new ThumbnailBuilder().setURL(user.displayAvatarURL()),
     )
@@ -371,25 +371,20 @@ function buildEquipmentContainer(user, stats) {
       new TextDisplayBuilder().setContent(
         `* Gun equiped: ${equippedGun.name} ${equippedGun.emoji}\n* Bullet using: ${
           equippedBullet.name
-        } ${equippedBullet.emoji}\n${activeLureText}`,
+        } ${equippedBullet.emoji}`,
       ),
+      new TextDisplayBuilder().setContent(activeLureText),
     );
-  const infoContainer = new ContainerBuilder()
+
+  const container = new ContainerBuilder()
     .setAccentColor(0xffffff)
-    .addSectionComponents(section)
+    .addSectionComponents(equipmentSection)
     .addActionRowComponents(new ActionRowBuilder().addComponents(gunSelect))
-    .addActionRowComponents(new ActionRowBuilder().addComponents(bulletSelect));
-
-  const lureSection = new SectionBuilder()
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(activeLureText));
-
-  const lureContainer = new ContainerBuilder()
-    .setAccentColor(0xffffff)
-    .addSectionComponents(lureSection)
+    .addActionRowComponents(new ActionRowBuilder().addComponents(bulletSelect))
     .addActionRowComponents(new ActionRowBuilder().addComponents(lureSelect))
     .addActionRowComponents(new ActionRowBuilder().addComponents(backBtn, statBtn, equipBtn));
 
-  return [infoContainer, lureContainer];
+  return [container];
 }
 
 function pickAnimal(areaKey, tier, stats, { luckBoost = false } = {}) {

--- a/command/shop.js
+++ b/command/shop.js
@@ -473,13 +473,20 @@ async function sendShop(user, send, resources, state = { page: 1, type: 'coin' }
     .addMediaGalleryComponents(mediaGallery)
     .addSeparatorComponents(new SeparatorBuilder());
 
-  const actionRows = [
+  const selectionRows = [
     new ActionRowBuilder().addComponents(pageSelect),
     new ActionRowBuilder().addComponents(typeSelect),
-    ...buttonRows,
   ];
 
-  const containers = distributeActionRows(container, actionRows, 0xffffff);
+  const containers = distributeActionRows(container, selectionRows, 0xffffff);
+
+  if (buttonRows.length) {
+    const buttonContainer = new ContainerBuilder().setAccentColor(0xffffff);
+    for (const row of buttonRows) {
+      buttonContainer.addActionRowComponents(row);
+    }
+    containers.push(buttonContainer);
+  }
 
   const message = await send({
     files: [attachment],


### PR DESCRIPTION
## Summary
- ensure the hunt equipment interface builds a single container so the interaction update succeeds
- group all shop item buttons inside their own container while leaving the selectors with the header

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2a48d76348325b0918b0a7270102d