### PR TITLE
Handle overdue spooky hunt heart decay

### DIFF
--- a/spookyHunt.js
+++ b/spookyHunt.js
@@ -104,9 +104,15 @@ async function sendEventMessage(channel, state) {
 function scheduleDecay(state, userId, client, saveData, decayTimers) {
   const entry = state.participants[userId];
   if (!entry || entry.eliminated || state.ended) return;
-  if (!entry.next_decay_at || entry.next_decay_at < Date.now()) {
+  if (!entry.next_decay_at) {
     entry.next_decay_at = Date.now() + DECAY_DURATION;
     saveData();
+  }
+  if (entry.next_decay_at <= Date.now()) {
+    clearTimeout(decayTimers.get(userId));
+    decayTimers.delete(userId);
+    handleDecay(state, userId, client, saveData, decayTimers).catch(() => {});
+    return;
   }
   clearTimeout(decayTimers.get(userId));
   const delay = Math.max(0, entry.next_decay_at - Date.now());


### PR DESCRIPTION
## Summary
- ensure overdue spooky hunt heart decay triggers immediately when participants miss the 24-hour window

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e352198e588325838472862bdc2c06